### PR TITLE
Issue #34: Supporting Dark Mode.

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -25,19 +25,19 @@ const Socials = [{
 }]
 ---
 
-<footer id="footer">
-    <div class="bg-ac px-4 pt-2 container-footer">
+<footer id="footer" class="bg-ac py-5">
+    <div class="py-5 px-4 pt-2 container-footer">
         <div class="row align-items-start justify-content-between">
             <div class="col-md-3 info-footer">
                 <dl class="mb-0 ac-text-light">
                     <dt class="display-65">Mailing Address</dt>
-                        <dd class="display-7">PO Box 46; Paeonian Springs, VA, 20129</dd>
+                    <dd class="display-7">PO Box 46; Paeonian Springs, VA, 20129</dd>
                     <dt class="display-65">Email</dt>
-                        <dd class="display-7">
-                            <a class="ac-text-light" href="mailto:info@accessiblecommunity.org">info@accessiblecommunity.org</a>
-                        </dd>
+                    <dd class="display-7">
+                      <a class="ac-text-light" href="mailto:info@accessiblecommunity.org">info@accessiblecommunity.org</a>
+                    </dd>
                     <dt class="display-65">Phone Number</dt>
-                        <dd class="display-7">703-651-6703</dd>
+                    <dd class="display-7">703-651-6703</dd>
                 </dl>
             </div>
             <div class="col-md-4">
@@ -97,31 +97,39 @@ const Socials = [{
 </footer>
 
 <style>
-    /* first declaration that is commented out below is for debugging purposes. */
-    /* * {
-        border: 1px solid white;
-    } */
+  /* first declaration that is commented out below is for debugging purposes. */
+  /* * {
+      border: 1px solid white;
+  } */
 
-    *:focus-visible {
+  .ac-text-light {
+    color: white;
+  }
+
+  *:focus-visible {
     outline: 6px dashed white;
     outline-offset: 3px;
     box-shadow: none;
     border-radius: 0.5rem;
-    }
+  }
 
-    .container-footer {
-        padding-bottom: 0.5rem; 
-    }
+  .container-footer {
+    padding-bottom: 0.5rem; 
+  }
 
-    .nav-footer {
-        margin-bottom: 2%;
-    }
+  .nav-footer {
+    margin-bottom: 2%;
+  }
 
-    .social-icon {
-        margin: 14.5px;
-    }
+  .social-icon {
+    margin: 14.5px;
+  }
 
-    .legal-footer {
-        border-top: 1px solid #dfe1ed;
-    }
+  .legal-footer {
+    border-top: 1px solid #dfe1ed;
+  }
+
+  dd + dt {
+    margin-top: 1.25em;
+  }
 </style>

--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -2,13 +2,15 @@
 import { Icon } from 'astro-icon';
 ---
   
-<header class="bg-white sticky-top">
-  <a class="visually-hidden-focusable position-absolute btn btn-lg skip-link" href="#main-content">Skip to Main Content</a>
+<header class="sticky-top bg-body">
+  <a class="visually-hidden-focusable position-absolute btn btn-lg btn-ac" href="#main-content">
+    Skip to Main Content
+  </a>
   <nav class="navbar navbar-expand-lg">
     <div class="container-fluid px-2">
       <div class="d-flex align-items-center">
         <div class="pe-2">
-          <button class="navbar-toggler dropdown-toggle toggle-menu ac-text" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+          <button class="navbar-toggler toggle-menu text-ac" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <Icon name="bi:list" class="bi bi-list" height="24" width="24"></Icon>
           </button>
         </div>
@@ -18,17 +20,15 @@ import { Icon } from 'astro-icon';
             Accessible <strong>Community</strong>
           </a>
         </div>
-        <div class="mt-2">
-          <button class="navbar-toggler dropdown-toggle btn border-2 toggle-menu text-ac" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span>Menu</span>
-          </button>
-        </div>
       </div>
       <div id="navbarSupportedContent" class="collapse align-items-center navbar-collapse justify-content-end">
           <ul class="navbar-nav my-2 main-list" aria-role="navigation">
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle display-65 text-ac" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <a class="nav-link d-inline-block pe-1 display-65 main-menu-item text-ac" href="/about" role="button">
                 About
+              </a>
+              <a class="nav-link d-inline-block ps-0 dropdown-toggle dropdown-toggle-split display-65 main-menu-item text-ac" href="/services" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <span class="visually-hidden">Toggle Services Menu</span>
               </a>
               <ul class="dropdown-menu p-0 menu-nav">
                 <li><a class="dropdown-item display-7 link-dropdown text-ac" href="">Mission, Vision, Values</a></li>
@@ -36,17 +36,18 @@ import { Icon } from 'astro-icon';
                 <li><a class="dropdown-item display-7 link-dropdown text-ac" href="">Leadership</a></li>
               </ul>
             </li>
-            <li class="nav-item">
-              <a class="nav-link display-65 main-menu-item ac-text" href="/services" role="button">
+            <li class="nav-item dropdown">
+              <a class="nav-link d-inline-block pe-1 display-65 main-menu-item text-ac" href="/services" role="button">
                 Services
               </a>
-              <!-- <ul class="dropdown-menu p-0 menu-nav">
-                <li><a class="dropdown-item link-dropdown text-ac" href=""><strong>t</strong>a11y</a></li>
-                <li><a class="dropdown-item link-dropdown text-ac" href=""><strong>mutu</strong>a11y</a></li>
-                <li><a class="dropdown-item link-dropdown text-ac" href=""><strong>loc</strong>a11y</a></li>
-                <li><a class="dropdown-item link-dropdown text-ac" href="">Tip of the Week</a></li>
-                <li><a class="dropdown-item link-dropdown text-ac" href="">Newsletter Sign-Up</a></li>
-              </ul> -->
+              <a class="nav-link d-inline-block ps-0 dropdown-toggle dropdown-toggle-split display-65 main-menu-item text-ac" href="/services" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <span class="visually-hidden">Toggle Services Menu</span>
+              </a>
+              <ul class="dropdown-menu p-0 menu-nav">
+                <li><a class="dropdown-item display-7 link-dropdown text-ac" href="https://www.ta11y.org/"><strong>t</strong>a11y</a></li>
+                <li><a class="dropdown-item display-7 link-dropdown text-ac" href="https://www.mutua11y.org/"><strong>mutu</strong>a11y</a></li>
+                <li><a class="dropdown-item display-7 link-dropdown disabled" href="#"><strong>loc</strong>a11y</a></li>
+              </ul>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle display-65 main-menu-item text-ac" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -82,35 +83,38 @@ import { Icon } from 'astro-icon';
               </ul>
             </li>
           </ul>
-          <a class="btn btn-ac my-2 ms-3 display-65 donate-button" href="/donate" role="button">Donate</a>
+          <a class="btn btn-ac my-2 mx-3 display-65 donate-button" href="/donate" role="button">Donate</a>
       </div>
     </div>
   </nav>
 </header>
 <slot />
 
-<style>
+<style lang="scss">
   /* first declaration that is commented out below is for debugging purposes. */
   /* * {
     outline: 1px solid black;
   } */
 
+  @import "../styles/ac.scss";
+  @import "bootstrap/scss/mixins/_color-mode.scss";
+
   *:focus-visible, .toggle-menu:focus {
-    outline: 6px dashed #041058;
+    outline: 6px dashed $ac-navy;
     outline-offset: 1px 2px;
     box-shadow: none;
     border-radius: 0.5rem;
   }
 
   .skip-link {
-    z-index: 1;
+    z-index: 5;
     top: 8px;
     left: 24px;
   }
 
-  .skip-link, .link-dropdown:hover {
+  .link-dropdown:hover {
     color: #dfe1ed;
-    background-color: #041058;
+    background: solid $ac-navy;
   }
 
   .toggle-menu {
@@ -148,7 +152,7 @@ import { Icon } from 'astro-icon';
     padding-left: 0.5rem;
   }
 
- .menu-nav {
+  .menu-nav {
     border-width: 8px;
   }
 
@@ -167,6 +171,31 @@ import { Icon } from 'astro-icon';
 
   [astro-icon="ac-logo"] {
     height: 1.1em;
+  }
+
+  @include color-mode(dark) {
+    *:focus-visible, .toggle-menu:focus {
+      outline: 6px dashed white;
+      outline-offset: 1px 2px;
+    }
+
+    .skip-link, .link-dropdown:hover {
+      color: var(--ac-navy);
+      background-color: white;
+    }
+
+    .main-menu-item:focus {
+      color: white;
+    }
+
+    .main-menu-item:hover, .main-menu-item:active {
+      background-color: white;
+    }
+
+    .navbar-toggler {
+      color: white !important;
+      background-color: $ac-navy;
+    }
   }
 </style>
 

--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -1,4 +1,5 @@
 ---
+import { Icon } from 'astro-icon';
 ---
   
 <header>
@@ -7,13 +8,13 @@
     <div class="container-fluid">
       <div class="d-flex me-2 stacking-helper">
         <div>
-          <a class="navbar-brand ac-text" href="/">
-              <img class="img-fluid align-text-top" style="height: 1.1em; " src="/images/ac_logo_blue.png" />
-              Accessible <strong>Community</strong>
+          <a class="navbar-brand text-ac" href="/">
+            <Icon name="ac-logo" class="img-fluid align-text-top" />
+            Accessible <strong>Community</strong>
           </a>
         </div>
         <div class="mt-2">
-          <button class="navbar-toggler dropdown-toggle btn border-2 toggle-menu ac-text" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+          <button class="navbar-toggler dropdown-toggle btn border-2 toggle-menu text-ac" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span>Menu</span>
           </button>
         </div>
@@ -21,13 +22,13 @@
       <div id="navbarSupportedContent" class="collapse align-items-center navbar-collapse justify-content-end">
           <ul class="navbar-nav me-2 my-2 main-list" aria-role="navigation">
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle toggle-dropdown ac-text" href="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <a class="nav-link dropdown-toggle toggle-dropdown text-ac" href="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 About
               </a>
               <ul class="dropdown-menu p-0 menu-nav">
-                <li><a class="dropdown-item link-dropdown ac-text" href="">Mission, Vision, Values</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="">History</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="">Leadership</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">Mission, Vision, Values</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">History</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">Leadership</a></li>
               </ul>
             </li>
             <li class="nav-item">
@@ -35,48 +36,48 @@
                 Services
               </a>
               <!-- <ul class="dropdown-menu p-0 menu-nav">
-                <li><a class="dropdown-item link-dropdown ac-text" href=""><strong>t</strong>a11y</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href=""><strong>mutu</strong>a11y</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href=""><strong>loc</strong>a11y</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="">Tip of the Week</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="">Newsletter Sign-Up</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href=""><strong>t</strong>a11y</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href=""><strong>mutu</strong>a11y</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href=""><strong>loc</strong>a11y</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">Tip of the Week</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">Newsletter Sign-Up</a></li>
               </ul> -->
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle toggle-dropdown ac-text" href="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <a class="nav-link dropdown-toggle toggle-dropdown text-ac" href="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 Team Members
               </a>
               <ul class="dropdown-menu p-0 menu-nav">
-                <li><a class="dropdown-item link-dropdown ac-text" href="/team/board">Board Members</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="/team/staff">Leadership and Staff</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="/team/mutua11y"><strong>mutu</strong>a11y Team</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="/team/ta11y"><strong>t</strong>a11y Team</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="">Previous Contributors</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="/team/board">Board Members</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="/team/staff">Leadership and Staff</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="/team/mutua11y"><strong>mutu</strong>a11y Team</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="/team/ta11y"><strong>t</strong>a11y Team</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">Previous Contributors</a></li>
               </ul>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle toggle-dropdown ac-text" href="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <a class="nav-link dropdown-toggle toggle-dropdown text-ac" href="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 Join Us
               </a>
               <ul class="dropdown-menu p-0 menu-nav">
-                <li><a class="dropdown-item link-dropdown ac-text" href="/donate">Donations</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="">Sponsorships</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="">Volunteer Form</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="">Policies</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="/donate">Donations</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">Sponsorships</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">Volunteer Form</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">Policies</a></li>
               </ul>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle toggle-dropdown ac-text" href="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <a class="nav-link dropdown-toggle toggle-dropdown text-ac" href="" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 Blog
               </a>
               <ul class="dropdown-menu p-0 menu-nav">
-                <li><a class="dropdown-item link-dropdown ac-text" href="">Accessibility</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="">Announcements</a></li>
-                <li><a class="dropdown-item link-dropdown ac-text" href="">Events</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">Accessibility</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">Announcements</a></li>
+                <li><a class="dropdown-item link-dropdown text-ac" href="">Events</a></li>
               </ul>
             </li>
           </ul>
-          <a class="btn btn-lg my-2 donate-link-navbar ac-text" href="/donate" role="button">Donate</a>
+          <a class="btn btn-lg btn-ac my-2 donate-link-navbar" href="/donate" role="button">Donate</a>
       </div>
     </div>
   </nav>
@@ -157,13 +158,17 @@
   .donate-link-navbar { 
     background-color: #041058;
   }
+
+  [astro-icon="ac-logo"] {
+    height: 1.1em;
+  }
 </style>
 
 <script>
     import { Collapse, Dropdown } from '~bootstrap-es'
 
     Array.from(document.querySelectorAll('.dropdown'))
-      .forEach(node => new Dropdown(node))
+      .forEach(node => new Dropdown(node));
     Array.from(document.querySelectorAll('.collapse'))
-      .forEach(node => new Collapse(node))
+      .forEach(node => new Collapse(node, { toggle: false }));
 </script>

--- a/astro/src/components/Hero.astro
+++ b/astro/src/components/Hero.astro
@@ -4,18 +4,27 @@ const {
   headline = "Hero heading.",
   theme = "ac",
   textColor = "white",
+  columns = "col-lg-6",
 } = Astro.props;
 
 import { getImage } from "astro:assets";
-const optimizedBg = await getImage({src: image, format: 'avif'})
-const heroBgUrl = `url(${optimizedBg.src})`;
+
+let heroBgUrl;
+
+if (image) {
+  const optimizedBg = await getImage({src: image, format: 'avif'})
+  heroBgUrl = `url(${optimizedBg.src})`;
+} else {
+  heroBgUrl = '';
+}
+
 ---
 <section class={`bg-${theme}`} style={`background: no-repeat center ${heroBgUrl}`} slot="header">
   <div class="container text-center py-5 px-4">
     <slot name="heading">
       <h2 class:list={["display-3 fw-bold", `text-${textColor}`]}>{ headline }</h2>
     </slot>
-    <div class:list={["col-lg-6 mx-auto", `text-${textColor}`]}>
+    <div class:list={[columns, "mx-auto", `text-${textColor}`]}>
       <slot />
     </div>
   </div>

--- a/astro/src/components/Profile.astro
+++ b/astro/src/components/Profile.astro
@@ -7,8 +7,8 @@ const { profile, mini } = Astro.props;
 const { Content } = await profile.render();
 const { name: fullName, title, picture, links } = profile.data;
 
-const NameTag = "h3";
-const TitleTag = mini ? "div" : "h4";
+const NameTag = "h2";
+const TitleTag = mini ? "div" : "h3";
 
 const name = (mini ? fullName.split(' ')[0] : fullName);
 const brandingThemes = {
@@ -40,12 +40,12 @@ const socialLinks = toPairs(links).map(([type, url]) => {
 ---
 
 <div class={`d-flex p-2 align-items-${mini ? 'center' : 'end'} ${mini ? 'shadow m-2' : ''}`}>
-  <img class="profile-pic" src={ picture.src } alt={`Drawn representation of ${title}`} />
+  <img class="profile-pic" src={ picture.src } alt={`Drawn representation of ${name}`} />
   <div class="flex-fill px-2">
-    <NameTag class:list={["mb-0", { small: mini }]}>
+    <NameTag class:list={["mb-0", { small: mini, h3: !mini }]}>
       { name }
     </NameTag>
-    <TitleTag class="text-body-secondary mb-0">
+    <TitleTag class:list={["text-body-secondary mb-0", { h4: !mini }]}>
       { title }
     </TitleTag>
     <ul class="list-inline">

--- a/astro/src/layouts/Layout.astro
+++ b/astro/src/layouts/Layout.astro
@@ -19,9 +19,6 @@ import Header from '../components/Header.astro';
   <meta name="generator" content={Astro.generator} />
   <link rel="icon" type="image/png" href="/images/favicon.png" />
   <title>{title} | Accessible Community</title>
-  <script>
-    import "../scripts/dark-mode.js";
-  </script>
 </head>
 
 
@@ -31,6 +28,11 @@ import Header from '../components/Header.astro';
       <h2>{ title }</h2>
     </slot>
   </Header>
+  <!-- <section class="bg-ac p-2">
+    <div class="container-fluid">
+      <h2 class="h4 text-white ms-4 my-0 p-0">{ title }</h2>
+    </div>
+  </section>   -->
   <main id="main-content">
     </slot>
     <slot />

--- a/astro/src/pages/donate.astro
+++ b/astro/src/pages/donate.astro
@@ -45,7 +45,7 @@ const donationLinks = [{
 
   <Hero image={ heroBg } headline="Together we can do so much.">
     <p class="lead mb-4">
-      <span class="ac-text-white text-brand">Accessible <strong>Community</strong></span> is a 501(c)3 organization.
+      <span class="text-brand">Accessible <strong>Community</strong></span> is a 501(c)3 organization.
       Your donation goes towards supporting our programs, accommodations and technology costs.
     </p>
     <div class="d-grid gap-4 d-sm-flex justify-content-sm-center">
@@ -61,7 +61,7 @@ const donationLinks = [{
   <Section theme="white">
     <div class="row justify-content-center">
       <div class="col col-lg-8">
-        <h2 class="display-4 ac-text mb-3">
+        <h2 class="display-4 text-ac mb-3">
           <Icon class="bi d-inline-block mb-1 me-1" name="ac-logo" style="height: 1em" alt="" />
           <span>Support our <strong>mission</strong>.</span>
         </h2>
@@ -70,7 +70,7 @@ const donationLinks = [{
     <div class="row justify-content-center">
       <div class="col col-lg-8 lead">
         <p>
-          Your support of <span class="ac-text text-brand">Accessible <strong>Community</strong></span> provides programs, accommodations and technology to...
+          Your support of <span class="text-ac text-brand">Accessible <strong>Community</strong></span> provides programs, accommodations and technology to...
         </p>
         <ul>
           <li>Help smaller organizations with limited resources engage and support people with disabilities,</li>
@@ -80,14 +80,14 @@ const donationLinks = [{
         </ul>
         <p>
           Contribute today and help make our communities more accessible. 
-          <span class="fw-bold ac-text">Thank you for your support!</span>
+          <span class="fw-bold text-ac">Thank you for your support!</span>
         </p>
       </div>
     </div>
   </Section>
 
   <Section theme="body-tertiary" shadow={true}>
-    <h2 class="display-4 text-center fw-bold ac-text my-3">How can I donate?</h2>
+    <h2 class="display-4 text-center fw-bold text-ac my-3">How can I donate?</h2>
     <div class="row justify-content-center">
       <div class="col-md-5 col-lg-3 d-flex flex-column justify-content-start">
         <div>

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -12,7 +12,7 @@ const daniela = await getEntry('profiles', 'daniela');
 
 ---
 
-<Layout title="Accessible Community">
+<Layout title="Home">
   <span slot="header" />
   <Hero image={ heroBg }>
     <h2 class="display-3 text-white heading py-5" slot="heading">

--- a/astro/src/pages/services.astro
+++ b/astro/src/pages/services.astro
@@ -5,7 +5,7 @@ import Hero from '../components/Hero.astro';
 import Layout from '../layouts/Layout.astro';
 import Section from '../components/Section.astro'
 
-import heroBg from '../images/hands-blue-1920x1080.png'
+import heroBg from '../images/girl-using-laptop-blue-1920x1080.png'
 
 const services = [{
   icon: 'ta11y-logo',
@@ -29,21 +29,25 @@ const services = [{
 <Layout title="Services">
   <span slot="header" />
 
-  <Hero image={ heroBg }>
-    <h2 class="display-3 text-white py-4" slot="heading">
+  <Hero image={ heroBg } columns="col-sm-12 col-md-9 col-lg-7 col-xl-6 col-xxl-5">
+    <div class="display-3 text-white py-4" slot="heading">
       An <strong>ethical</strong> technology <strong>nonprofit</strong>.
-    </h2>
-    <p class="lead">
-      At <span class="ac-text-white text-brand">Accessible <strong>Community</strong></span>,
-      we believe that technology <br/>
-      can <strong>build community</strong> and <strong>increase equity</strong>.<br/>
-      For people with disabilities and their caretakers,<br/>
-      <strong>community and equity</strong> are two important goals.
-    </p>
+    </div>
+    <div class="hero-bd p-1">
+      <p class="lead mb-0">
+        At <span class="text-brand">Accessible <strong>Community</strong></span>,
+        we believe that technology
+        can <strong>build community</strong> and <strong>increase equity</strong>.
+      </p>
+      <p class="lead">
+        For people with disabilities and their caretakers,
+        <strong>community and equity</strong> are two important goals.
+      </p>
+    </div>
   </Hero>
 
   <Section theme="body-tertiary p-4">
-    <h2 class="display-4 text-ac">Our <strong>tools</strong> and <strong>services</strong></h2>
+    <h1 class="display-4 text-ac">Our <strong>tools</strong> and <strong>services</strong></h1>
     <p class="border-bottom pb-2 lead text-ac me-4">
       We create tools and services to <strong>teach accessibility</strong>
       and <strong>promote accessible organizations</strong>. We practice what we preach; the tools we develop
@@ -58,7 +62,7 @@ const services = [{
             <div class="feature-icon d-inline-flex align-items-center justify-content-center text-bg-ac bg-gradient">
               <Icon class="bi" name={ icon } height="1.5em" />
               </div>
-            <h3 class="my-1 fs-1 text-ac" set:html={ title }></h3>
+            <h2 class="my-1 fs-1 text-ac" set:html={ title }></h2>
           </div>
           <p class="mx-5 me-4" set:html={text} />
           { link ? 
@@ -78,6 +82,13 @@ const services = [{
 </Layout>
 
 <style>
+  .hero-bd {
+    background-color: #04105860;
+    border-radius: 0.2em;
+    margin-left: 1em;
+    margin-right: 1em;
+  }
+
   .feature-icon {
     width: 2.5rem;
     height: 2.5rem;

--- a/astro/src/pages/team/[tag].astro
+++ b/astro/src/pages/team/[tag].astro
@@ -13,7 +13,10 @@ export async function getStaticPaths() {
 }
 
 import Layout from '../../layouts/Layout.astro';
+import Hero from '../../components/Hero.astro';
 import Profile from '../../components/Profile.astro';
+import Section from '../../components/Section.astro';
+
 import { sortBy } from 'lodash-es';
 
 const { tag } = Astro.params;
@@ -28,17 +31,23 @@ const profiles = sortBy(
 ---
 
 <Layout title={title}>
-	<div class="mb-3" slot="header">
-		<h2 class="mb-0">{ title }</h2>
-    <a href="/team" class="text-secondary">&leftarrow; Back to Team</a>
-	</div>
-  <ul class={mini ? 'mini list-inline' : 'list-group'}>
-    { profiles.map((p) =>
-      <li class={mini ? 'list-inline-item' : 'd-block'}>
-        <Profile profile={p} mini={mini} />
-      </li>
-    )}
-  </ul>
+  <span slot="header" />
+
+  <Hero image={ null } columns="col-lg-6">
+    <h1 class="display-3 text-white p-0" slot="heading">
+      Our {title}
+    </h1>
+  </Hero>
+
+  <Section theme="body-tertiary py-3 px-5">
+    <ul class={mini ? 'mini list-inline' : 'list-group'}>
+      { profiles.map((p) =>
+        <li class={mini ? 'list-inline-item' : 'd-block'}>
+          <Profile profile={p} mini={mini} />
+        </li>
+      )}
+    </ul>
+  </Section>
 </Layout>
 
 <style>

--- a/astro/src/styles/ac.scss
+++ b/astro/src/styles/ac.scss
@@ -1,6 +1,9 @@
 @charset "UTF-8";
 
-$ac-navy: #041058;
+$ac-navy:            #041058;
+$ac-navy-rgb:          4, 16, 88;
+
+$color-mode-type:      media-query;
 
 :root {
   --ac-navy: $ac-navy;

--- a/astro/src/styles/bootstrap.scss
+++ b/astro/src/styles/bootstrap.scss
@@ -29,16 +29,16 @@ $display-font-sizes: (
 $display-font-family: 'Archivo';
 $display-font-weight: 400;
 
-
 $container-padding-x:  3rem;
-$color-mode-type:      data;
+
+$color-mode-type:      media-query;
 
 // 3. Include remainder of required Bootstrap stylesheets (including any separate color mode stylesheets)
 @import "bootstrap/scss/variables";
 @import "bootstrap/scss/variables-dark";
 
 // 4. Include any default map overrides here
-$brand-colors: (
+$custom-colors: (
   "ac": #041058,
   "facebook": #4267B2,
   "instagram": #5B51D8,
@@ -49,12 +49,32 @@ $brand-colors: (
   "threads": black,
   "twitter": #1DA1F2,
 );
-$theme-colors: map-merge($theme-colors, $brand-colors);
+$theme-colors: map-merge($theme-colors, $custom-colors);
 
-// 5. Include remainder of required parts
+// 5a. Include remainder of required parts
 @import "bootstrap/scss/maps";
 @import "bootstrap/scss/mixins";
 @import "bootstrap/scss/utilities";
+
+// Custom Themes: Light mode.
+$custom-colors-text: ("ac": #041058);
+$custom-colors-bg-subtle: ("ac": #8d9dfa);
+$custom-colors-border-subtle: ("ac": #3754f6);
+
+$theme-colors-text: map-merge($theme-colors-text, $custom-colors-text);
+$theme-colors-bg-subtle: map-merge($theme-colors-bg-subtle, $custom-colors-bg-subtle);
+$theme-colors-border-subtle: map-merge($theme-colors-border-subtle, $custom-colors-border-subtle);
+
+// Custom Themes: Dark mode
+$custom-colors-text-dark: ("ac": #8d9dfa);
+$custom-colors-bg-subtle-dark: ("ac": #041058);
+$custom-colors-border-subtle-dark: ("ac": #8d9dfa);
+
+$theme-colors-text-dark: map-merge($theme-colors-text-dark, $custom-colors-text-dark);
+$theme-colors-bg-subtle-dark: map-merge($theme-colors-bg-subtle-dark, $custom-colors-bg-subtle-dark);
+$theme-colors-border-subtle-dark: map-merge($theme-colors-border-subtle-dark, $custom-colors-border-subtle-dark);
+
+// 5b. Include remainder of required parts
 @import "bootstrap/scss/root";
 @import "bootstrap/scss/reboot";
 
@@ -76,27 +96,14 @@ $theme-colors: map-merge($theme-colors, $brand-colors);
 @import "bootstrap/scss/utilities/api";
 
 // 8. Add additional custom code here
-.ac-text {
-    color: #041058;
-    text-decoration: none;
-}
-
-.ac-text-light, .ac-text-dark {
-  font-weight: 400;
-}
-.ac-text-light > strong,
-.ac-text-dark > strong {
-  font-weight: 600;
-}
-.ac-text-light {
-  color: white;
-}
-.ac-text-dark {
-  color: var(--ac-navy);
+@include color-mode(dark) {
+  .text-ac {
+    color: white !important;
+  }
 }
 
 @include color-mode(dark) {
-    .ac-text, h1, h2, h3, h4, h5, h6 {
+    h1, h2, h3, h4, h5, h6 {
         color: var(--bs-primary-text-emphasis);
     }
     .bi {

--- a/astro/src/styles/bootstrap.scss
+++ b/astro/src/styles/bootstrap.scss
@@ -40,6 +40,8 @@ $color-mode-type:      media-query;
 @import "bootstrap/scss/variables";
 @import "bootstrap/scss/variables-dark";
 
+@import "./ac";
+
 // 4. Include any default map overrides here
 $custom-colors: (
   "ac": #041058,


### PR DESCRIPTION
Changed the dark mode implementation to a straight media query, which should remove the flashing between pages. Removed the duplicative 'ac-text' classes, as we had `text-ac` in the bootstrap themes. Made sure certain text and icons worked with dark mode, switching to SVGs where available.

Fixes #34 