### PR TITLE
Left-align content inside mini profiles (#50 continued).

### DIFF
--- a/astro/src/pages/team/[tag].astro
+++ b/astro/src/pages/team/[tag].astro
@@ -66,7 +66,7 @@ const crumbs = [{
   <Section theme="body-tertiary" fluid={mini}>
     <ul class={mini ? 'mini list-inline text-center' : 'list-group'}>
       { profiles.map((p) =>
-        <li class={mini ? 'list-inline-item' : 'd-block'}>
+        <li class={mini ? 'list-inline-item text-start' : 'd-block'}>
           <Profile profile={p} mini={mini} />
         </li>
       )}


### PR DESCRIPTION
Added 'text-start' class to mini profile content to keep profiles centered but left-align the content of the mini profiles.