### PR TITLE
Fix misspelled label for textarea (Fixes #113).

### DIFF
--- a/astro/src/pages/volunteer.astro
+++ b/astro/src/pages/volunteer.astro
@@ -179,7 +179,7 @@ const crumbs = [{
       </div>
       <div class="form-floating mb-3">
         <label for="accommodateTextarea" class="form-label mb-1">Please list any accomodations needed for remote meetings and work.</label>
-        <textarea class="form-control w-100 form-text-area" id="accomodateTextarea"></textarea>
+        <textarea class="form-control w-100 form-text-area" id="accommodateTextarea"></textarea>
       </div>
       <div class="col-md-6 mx-auto">
         <button type="submit" class="btn bg-ac text-white w-100 general-button">Submit</button>


### PR DESCRIPTION
Corrected misspelled label, so now `textarea` has an associated label in the Volunteer form.

Fixes #113
Fixes #108 