### PR TITLE
Alexis/svg image roles

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -81,7 +81,7 @@ const Socials = [{
                         { Socials.map(({icon, href, className, name}) =>
                         <li class="d-inline-block">
                             <a class="d-inline-block ac-text-light" href={ href } target="_blank">
-                                <Icon name={ icon } class={ className } class= "social-icon" height="29" width="29" alt={ name }></Icon> 
+                                <Icon name={ icon } class={ className } class="social-icon" height="29" width="29" role="img" aria-label={ name }></Icon> 
                             </a>
                         </li>
                         )}

--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -23,7 +23,7 @@ const breadCrumbs = isEmpty(crumbs) && title != 'Home' ? [{ name: 'Home', href: 
         Skip to Main Content
       </a>
       <div class="d-none d-sm-block navbar-brand me-2">
-        <Icon name="ac-logo" class="brand-logo" role="img" aria-label="Accessible Community Logo."/>
+        <Icon name="ac-logo" class="brand-logo" role="img" aria-hidden="true"/>
       </div>
       <div class="me-auto my-1">
         <a class="navbar-brand lh-sm" href="/">Accessible <strong>Community</strong></a>

--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -23,10 +23,10 @@ const breadCrumbs = isEmpty(crumbs) && title != 'Home' ? [{ name: 'Home', href: 
         Skip to Main Content
       </a>
       <div class="d-none d-sm-block navbar-brand me-2">
-        <Icon name="ac-logo" class="brand-logo" role="img" aria-label=""/>
+        <Icon name="ac-logo" class="brand-logo" role="img" aria-label="Accessible Community Logo."/>
       </div>
       <div class="me-auto my-1">
-        <a class="navbar-brand lh-sm" href="/" tabindex="-1">Accessible <strong>Community</strong></a>
+        <a class="navbar-brand lh-sm" href="/">Accessible <strong>Community</strong></a>
         <nav aria-label="breadcrumb">
           <ol class="breadcrumb lh-sm">
             { breadCrumbs.map(({name, href}) =>

--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -23,7 +23,7 @@ const breadCrumbs = isEmpty(crumbs) && title != 'Home' ? [{ name: 'Home', href: 
         Skip to Main Content
       </a>
       <div class="d-none d-sm-block navbar-brand me-2">
-        <Icon name="ac-logo" class="brand-logo" />
+        <Icon name="ac-logo" class="brand-logo" role="img" aria-label=""/>
       </div>
       <div class="me-auto my-1">
         <a class="navbar-brand lh-sm" href="/" tabindex="-1">Accessible <strong>Community</strong></a>

--- a/astro/src/pages/donate.astro
+++ b/astro/src/pages/donate.astro
@@ -62,7 +62,7 @@ const crumbs = [{
       { heroButtons.map(({icon, href, name, className}) =>
         <a class="btn btn-primary border-light d-flex justify-content-center align-items-center px-4 gap-1 hero-button" href={ href } target="_blank">
           <span class={ className }>Donate with</span>
-          <Icon class="bi" alt={ name } name={ icon } />
+          <Icon class="bi" name={ icon } role="img" aria-label={ name }/>
         </a>
       )}
     </div>
@@ -72,7 +72,7 @@ const crumbs = [{
     <div class="row justify-content-center">
       <div class="col col-lg-10">
         <h2 class="display-3 mb-3">
-          <Icon class="bi d-inline-block mb-1 me-1" name="ac-logo" style="height: 1em" alt="" />
+          <Icon class="bi d-inline-block mb-1 me-1" name="ac-logo" style="height: 1em" role="img" aria-hidden="true"/>
           <span class="">Support our <strong>mission</strong>.</span>
         </h2>
         <div class="lead">
@@ -128,7 +128,7 @@ const crumbs = [{
         <div class="d-grid d-sm-flex flex-lg-column justify-content-sm-center gap-3 pb-3">
           { donationLinks.map(({icon, href, title, theme}) =>
             <a class:list={[`btn btn-sm btn-primary rounded-2 shadow-sm`]} href={ href } target="_blank">
-              <Icon class="bi mx-auto" aria-hidden="true" name={ icon } />
+              <Icon class="bi mx-auto" name={ icon } aria-hidden="true"/>
               { title }
             </a>
           )}

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -117,7 +117,7 @@ const daniela = await getEntry('profiles', 'daniela');
     <div class="d-flex flex-column flex-xl-row gap-4 py-3 justify-content-lg-evenly text-primary">
       <ThemedBox text={true} border={1} class="border-primary col col-xl-3 shadow rounded">
         <h3 class="display-5">
-          <Icon class="bi" name="loca11y-logo" height="1.1em" role="img" aria-label="loca11y logo"/>
+          <Icon class="bi" name="loca11y-logo" height="1.1em" role="img" aria-hidden="true"/>
           <span class="text-brand">
             <strong>loc</strong>a11y.<strong>org</strong>
           </span>
@@ -132,7 +132,7 @@ const daniela = await getEntry('profiles', 'daniela');
       </ThemedBox>
       <ThemedBox text={true} border={1} class="border-primary col col-xl-3 shadow rounded">
         <h3 class="display-5">
-          <Icon class="bi" name="ta11y-logo" height="1em" role="img" aria-label="ta11y logo"/>
+          <Icon class="bi" name="ta11y-logo" height="1em" role="img" aria-hidden="true"/>
           <span class="text-brand">
             <strong>t</strong>a11y.<strong>org</strong>
           </span>
@@ -150,7 +150,7 @@ const daniela = await getEntry('profiles', 'daniela');
       </ThemedBox>
       <ThemedBox text={true} border={1} class="border-primary col col-xl-3 shadow rounded">
         <h3 class="display-5">
-          <Icon class="bi" name="mutua11y-logo" height="1em" role="img" aria-label="ta11y logo"/>
+          <Icon class="bi" name="mutua11y-logo" height="1em" role="img" aria-hidden="true"/>
           <span class="text-brand">
             <strong>mutu</strong>a11y.<strong>org</strong>
           </span>

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -117,7 +117,7 @@ const daniela = await getEntry('profiles', 'daniela');
     <div class="d-flex flex-column flex-xl-row gap-4 py-3 justify-content-lg-evenly text-primary">
       <ThemedBox text={true} border={1} class="border-primary col col-xl-3 shadow rounded">
         <h3 class="display-5">
-          <Icon class="bi" name="loca11y-logo" height="1.1em" />
+          <Icon class="bi" name="loca11y-logo" height="1.1em" role="img" aria-label="loca11y logo"/>
           <span class="text-brand">
             <strong>loc</strong>a11y.<strong>org</strong>
           </span>
@@ -132,7 +132,7 @@ const daniela = await getEntry('profiles', 'daniela');
       </ThemedBox>
       <ThemedBox text={true} border={1} class="border-primary col col-xl-3 shadow rounded">
         <h3 class="display-5">
-          <Icon class="bi" name="ta11y-logo" height="1em" />
+          <Icon class="bi" name="ta11y-logo" height="1em" role="img" aria-label="ta11y logo"/>
           <span class="text-brand">
             <strong>t</strong>a11y.<strong>org</strong>
           </span>
@@ -150,7 +150,7 @@ const daniela = await getEntry('profiles', 'daniela');
       </ThemedBox>
       <ThemedBox text={true} border={1} class="border-primary col col-xl-3 shadow rounded">
         <h3 class="display-5">
-          <Icon class="bi" name="mutua11y-logo" height="1em" />
+          <Icon class="bi" name="mutua11y-logo" height="1em" role="img" aria-label="ta11y logo"/>
           <span class="text-brand">
             <strong>mutu</strong>a11y.<strong>org</strong>
           </span>

--- a/astro/src/pages/services.astro
+++ b/astro/src/pages/services.astro
@@ -71,7 +71,7 @@ const services = [{
               <a href={`#${name}`} class="icon-link  text-nowrap me-4">
                 Learn more
                 <span class="visually-hidden">about {name}.org</span>
-                <Icon name="bi:arrow-down-square" class="bi" role="img" aria-label="Down Arrow"/>
+                <Icon name="bi:arrow-down-square" class="bi" role="img" aria-hidden="true"/>
               </a>
               { link ?
                 <div class="text-primary text-nowrap">

--- a/astro/src/pages/services.astro
+++ b/astro/src/pages/services.astro
@@ -59,7 +59,7 @@ const services = [{
         <div class="feature col d-flex flex-column justify-content-between">
           <div class="d-flex align-items-center gap-2 mb-1">
             <div class="feature-icon d-inline-flex align-items-center justify-content-center text-bg-primary bg-gradient">
-              <Icon class="bi" name={ icon } height="1.5em" />
+              <Icon class="bi" name={ icon } height="1.5em" role="img" aria-hidden="true"/>
               </div>
             <h2 class="my-1 fs-1 text-primary" set:html={ title }></h2>
           </div>

--- a/astro/src/pages/services.astro
+++ b/astro/src/pages/services.astro
@@ -71,7 +71,7 @@ const services = [{
               <a href={`#${name}`} class="icon-link  text-nowrap me-4">
                 Learn more
                 <span class="visually-hidden">about {name}.org</span>
-                <Icon name="bi:arrow-down-square" class="bi" />
+                <Icon name="bi:arrow-down-square" class="bi" role="img" aria-label="Down Arrow"/>
               </a>
               { link ?
                 <div class="text-primary text-nowrap">


### PR DESCRIPTION
Adds role="img" and aria-label or aria-hidden for SVGs that had alt attributes. Only concern is for social icons, as they no longer have an alt attribute that can show up in case the icons are not visible. Also, I am not sure if the Accessible Community logo in the header should function as a clickable button, but I just gave it an aria-hidden="true" for now.

Fixes #119
Fixes #111
Fixes #110
Fixes #109
Fixes #107
Fixes #105