### PR TITLE
Fix for SVGs in Footer

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -84,7 +84,7 @@ const Socials = [{
           { Socials.map(({icon, href, className, name}) =>
             <li class="d-inline-block">
               <a class="d-inline-block link-light" href={ href } target="_blank">
-                <Icon name={ icon } class={ className } class= "social-icon" height="29" width="29" alt={ name }></Icon> 
+                <Icon name={ icon } class={ className } class= "social-icon" height="29" width="29" role="img" aria-label={ name }></Icon> 
               </a>
             </li>
           )}


### PR DESCRIPTION
Added back aria-label method instead of alt text, as this got changed back on accident.