### PR TITLE
Provide aria-label for Email/LinkedIn Icons in Profiles for Team Pages

### DIFF
--- a/astro/src/components/Profile.astro
+++ b/astro/src/components/Profile.astro
@@ -57,8 +57,7 @@ const socialLinks = toPairs(links).map(([type, url]) => {
       { socialLinks.map((sl) =>
         <li class="list-inline-item">
           <a class:list={["icon-link align-text-top", `text-${sl.theme}`]} href={ sl.href } target="_blank">
-            <Icon class:list={['bi', { lg: !mini }]} aria-hidden="true" name={ sl.iconName } />
-            <span class="visually-hidden">{name}'s {`${sl.serviceName} ${sl.description}`}</span>
+            <Icon class:list={['bi', { lg: !mini }]} role="img" aria-label={`link to ${name}'s ${sl.serviceName} ${sl.description}`} name={ sl.iconName } />
           </a>
         </li>
       )}


### PR DESCRIPTION
Allow these links to be read by assistive technology. I'm not sure I've done this the best way, but I was able to get it working so it is clear these are links and where they go.