### PR TITLE
Update the WCAG link in the Welcome to Website blog post

### DIFF
--- a/astro/src/content/blogs/welcome-website.md
+++ b/astro/src/content/blogs/welcome-website.md
@@ -13,6 +13,6 @@ Our new site uses mainly [Astro](https://astro.build) and [Bootstrap 5](https://
 
 My sincere thanks to Brian Montgomery and Alexis for the many hours they have worked to get this ready.   
 
-We are striving to be [WCAG 2.2 A, AA, and AAA](https://www.w3.org/TR/WCAG22/_) compliant and follow [Making Content Usable for People with Cognitive and Learning Disabilities](https://www.w3.org/TR/coga-usable/). We will be conducting more accessibility testing over the next few weeks.
+We are striving to be [WCAG 2.2 A, AA, and AAA](https://www.w3.org/TR/WCAG22/) compliant and follow [Making Content Usable for People with Cognitive and Learning Disabilities](https://www.w3.org/TR/coga-usable/). We will be conducting more accessibility testing over the next few weeks.
 
 If you find an accessibility issue, please let us know at website@accessiblecommunity.org. 


### PR DESCRIPTION
Update the WCAG link in the Welcome to Website blog post, as it did not lead to the intended page.