### PR TITLE
Issue #180: Fixing breadcrumb issues on smaller screens

### DIFF
--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -130,7 +130,7 @@ const breadCrumbs =
       {
         breadCrumbs.map(({ name, href }) => (
           <li class="breadcrumb-item">
-            <a href={href} class="text-primary">
+            <a href={href} class="link-primary text-truncate">
               {name}
             </a>
           </li>
@@ -156,6 +156,9 @@ const breadCrumbs =
   #header-navbar {
     min-width: 320px;
   }
+  #breadcrumbs-nav {
+    min-width: 250px;
+  }
 
   .skip-link:focus,
   .skip-link:focus-within {
@@ -171,7 +174,7 @@ const breadCrumbs =
     height: 2.5rem;
   }
   [astro-icon="bi:list"] {
-    height: 1.5rem;
+    height: 1.25rem;
   }
   #brand-nav {
     height: 3.5rem;
@@ -182,7 +185,7 @@ const breadCrumbs =
   }
   @include media-breakpoint-down(lg) {
     #breadcrumbs-nav {
-      left: 3.6rem;
+      left: 3.333rem;
     }
   }
 
@@ -215,19 +218,24 @@ const breadCrumbs =
     #breadcrumbs-nav .breadcrumb-item {
       --bs-breadcrumb-item-padding-x: 0.4rem;
       font-size: 0.9em;
-      line-height: 1em;
+      line-height: 1.1em;
     }
   }
   @include media-breakpoint-down(sm) {
     #breadcrumbs-nav .breadcrumb-item {
       --bs-breadcrumb-item-padding-x: 0.3rem;
-      font-size: 0.8em;
+      font-size: 0.9em;
+    }
+    .breadcrumb-item > .text-truncate {
+      max-width: 8em;
     }
   }
   @include media-breakpoint-down(xs) {
     #breadcrumbs-nav .breadcrumb-item {
       --bs-breadcrumb-item-padding-x: 0.25rem;
-      font-size: 0.75em;
+    }
+    .breadcrumb-item > .text-truncate {
+      max-width: 6em;
     }
   }
 

--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -18,7 +18,7 @@ const breadCrumbs =
 ---
 
 <header class="sticky-top">
-  <div class="navbar navbar-expand-lg align-items-top">
+  <div id="header-navbar" class="navbar navbar-expand-lg align-items-top">
     <a
       class="visually-hidden-focusable btn btn-primary skip-link"
       href="#main-content"
@@ -26,16 +26,8 @@ const breadCrumbs =
       Skip to Main Content
     </a>
     <div id="brand-nav" class="container-fluid px-3">
-      <div class="d-none d-sm-block navbar-brand me-2">
-        <Icon name="ac-logo" class="brand-logo" role="img" aria-hidden="true" />
-      </div>
-      <div class="my-1 flex-fill align-self-start">
-        <a class="navbar-brand" href="/"
-          >Accessible <strong>Community</strong></a
-        >
-      </div>
       <button
-        class="navbar-toggler px-1"
+        class="navbar-toggler px-1 me-2"
         type="button"
         data-bs-toggle="collapse"
         data-bs-target="#site-nav"
@@ -43,8 +35,16 @@ const breadCrumbs =
         aria-expanded="false"
         aria-label="Toggle site navigation"
       >
-        <Icon name="bi:list" class="bi" height="1.4em" width="1.4em" />
+        <Icon name="bi:list" class="bi" />
       </button>
+      <div class="d-none d-lg-block navbar-brand me-2">
+        <Icon name="ac-logo" class="brand-logo" role="img" aria-hidden="true" />
+      </div>
+      <div class="my-1 flex-fill align-self-start">
+        <a class="navbar-brand" href="/"
+          >Accessible <strong>Community</strong></a
+        >
+      </div>
     </div>
     <nav id="site-nav" class="collapse navbar-collapse mx-3" aria-label="Site">
       <ul class="navbar-nav my-1 mx-4">
@@ -151,6 +151,11 @@ const breadCrumbs =
   } */
 
   @import "../styles/dark-mode.scss";
+  @import "../styles/responsive-sizing.scss";
+
+  #header-navbar {
+    min-width: 320px;
+  }
 
   .skip-link:focus,
   .skip-link:focus-within {
@@ -165,6 +170,9 @@ const breadCrumbs =
   [astro-icon="ac-logo"] {
     height: 2.5rem;
   }
+  [astro-icon="bi:list"] {
+    height: 1.5rem;
+  }
   #brand-nav {
     height: 3.5rem;
   }
@@ -172,10 +180,9 @@ const breadCrumbs =
     top: 2.333rem;
     left: 4rem;
   }
-  @media (max-width: 576px) {
-    // TODO: Use BS sizing later.
+  @include media-breakpoint-down(lg) {
     #breadcrumbs-nav {
-      left: 1rem;
+      left: 3.6rem;
     }
   }
 
@@ -190,6 +197,38 @@ const breadCrumbs =
   .breadcrumb-item > .text-truncate {
     display: inline-block;
     max-width: 10em;
+  }
+  @include media-breakpoint-down(md) {
+    .navbar-brand {
+      --bs-navbar-brand-font-size: 1.1rem;
+      vertical-align: sub;
+    }
+  }
+  @include media-breakpoint-down(sm) {
+    .navbar-brand {
+      --bs-navbar-brand-font-size: 1rem;
+      vertical-align: sub;
+    }
+  }
+
+  @include media-breakpoint-down(md) {
+    #breadcrumbs-nav .breadcrumb-item {
+      --bs-breadcrumb-item-padding-x: 0.4rem;
+      font-size: 0.9em;
+      line-height: 1em;
+    }
+  }
+  @include media-breakpoint-down(sm) {
+    #breadcrumbs-nav .breadcrumb-item {
+      --bs-breadcrumb-item-padding-x: 0.3rem;
+      font-size: 0.8em;
+    }
+  }
+  @include media-breakpoint-down(xs) {
+    #breadcrumbs-nav .breadcrumb-item {
+      --bs-breadcrumb-item-padding-x: 0.25rem;
+      font-size: 0.75em;
+    }
   }
 
   @include color-mode(dark) {

--- a/astro/src/components/ImageFigure.astro
+++ b/astro/src/components/ImageFigure.astro
@@ -9,17 +9,25 @@ interface Props {
   caption?: string;
 }
 
-const { class: extraClasses, src, alt, imageClass = undefined, caption = undefined } = Astro.props;
+const {
+  class: extraClasses,
+  src,
+  alt,
+  imageClass = undefined,
+  caption = undefined,
+} = Astro.props;
 ---
 
 <figure class:list={["figure", extraClasses]}>
-  <Image {src} class:list={["figure-img img-fluid rounded", imageClass]} alt={alt} />
+  <Image
+    {src}
+    class:list={["figure-img img-fluid rounded", imageClass]}
+    alt={alt}
+  />
   {
-    (caption || Astro.slots.has('caption')) && (
+    (caption || Astro.slots.has("caption")) && (
       <figcaption class="figure-caption">
-        <slot name="caption">
-          { caption }
-        </slot>
+        <slot name="caption">{caption}</slot>
       </figcaption>
     )
   }

--- a/astro/src/pages/about/mission.astro
+++ b/astro/src/pages/about/mission.astro
@@ -51,7 +51,7 @@ import partnerImage from "../../images/np_Business-partners-discussing-work-arra
           inclusive world.
         </p>
       </div>
-      <div class="col-10 col-sm-8 col-lg-6 col-xl-5 col-xxl-4">
+      <div class="col col-sm-10 col-md-8 col-lg-6 col-xl-5 col-xxl-4">
         <Image
           src={missionImage}
           class="img-fluid"
@@ -176,7 +176,7 @@ import partnerImage from "../../images/np_Business-partners-discussing-work-arra
   <ShadowBoxSection theme="secondary-subtle">
     <div class="row gap-4">
       <h2 class="col display-3 text-center py-3">
-        <strong>Communities</strong> are made up of <strong class="text-nowrap"
+        <strong>Communities</strong> are made up of <strong
           >small organizations</strong
         >.
       </h2>

--- a/astro/src/styles/bootstrap.scss
+++ b/astro/src/styles/bootstrap.scss
@@ -44,6 +44,19 @@ $display-font-weight: 400;
 $lead-font-size:              1.25rem;
 $lead-font-weight:            400;
 
+//*********************************
+//* Breakpoints for Responsiveness
+//********************************/
+$grid-breakpoints: (
+  xxs: 0,
+  xs: 400px,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+  xxl: 1400px
+);
+
 //***********************
 //* Navbar & Breadcrumbs
 //**********************/

--- a/astro/src/styles/responsive-sizing.scss
+++ b/astro/src/styles/responsive-sizing.scss
@@ -1,0 +1,11 @@
+$grid-breakpoints: (
+  xxs: 0,
+  xs: 400px,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px,
+  xxl: 1400px
+);
+
+@import "bootstrap/scss/mixins/breakpoints";


### PR DESCRIPTION
Attempting to fix the breadcrumb issues on smaller screens.

* Moved the toggle menu back to the left, replacing the logo when things get to medium or smaller.
* Adjusted font-size for header elements at smaller screens.
* Added `responsive-sizing.scss` to assist in components that need to be responsive.
* A couple of other sizing and `prettier` issues.

Fixes #180.