### PR TITLE
Place Blog Content into Article Element, Links into Nav Element

### DIFF
--- a/astro/src/layouts/BlogLayout.astro
+++ b/astro/src/layouts/BlogLayout.astro
@@ -101,66 +101,72 @@ import ThemedSection from "../components/ThemedSection.astro";
           <Content />
         </article>
       </div>
-      <div class:list={[sidebar ? "col" : "d-none d-lg-block", "col-lg-3"]}>
-        {
-          isEmpty(blogs) ? "" : (
-            <>
-              <h2 class="text-info-emphasis display-6">Blog Posts</h2>
-              <ul>
-                {blogs.map((b) => (
-                  <li>
-                    <a href={`/blog/${b.slug}`}>{b.data.title}</a>
-                  </li>
-                ))}
-              </ul>
-            </>
-          )
-        }
-        {
-          isEmpty(topics) ? "" : (
-            <>
-              <h2 class="text-info-emphasis display-6">Topics</h2>
-              <ul>
-                {topics.map((cat) => (
-                  <li>
-                    <a href={`/blog/topics/${cat}`}>{startCase(cat)}</a>
-                  </li>
-                ))}
-              </ul>
-            </>
-          )
-        }
-        {
-          isEmpty(authors) ? "" : (
-            <>
-              <h2 class="text-info-emphasis display-6">Authors</h2>
-              <ul>
-                {authors.map((author) => (
-                  <li>
-                    <a href={`/blog/authors/${author.slug}`}>
-                      {author.data.name}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </>
-          )
-        }
-        {
-          isEmpty(dates) ? "" : (
-            <>
-              <h2 class="text-info-emphasis display-6">Dates</h2>
-              <ul>
-                {dates.map((month) => (
-                  <li>
-                    <a href={`/blog/dates/${kebabCase(month)}`}>{month}</a>
-                  </li>
-                ))}
-              </ul>
-            </>
-          )
-        }
-      </div>
+      <nav class:list={[sidebar ? "col" : "d-none d-lg-block", "col-lg-3"]} aria-label="Blog">
+        <ul class="list-unstyled">
+          {
+            isEmpty(blogs) ? "" : (
+              <>
+                <li class="text-info-emphasis"><span class="display-6">Blog Posts</span>
+                  <ul class="mt-1 mb-3 ps-4 list-disc">
+                    {blogs.map((b) => (
+                      <li>
+                        <a href={`/blog/${b.slug}`}>{b.data.title}</a>
+                      </li>
+                    ))}
+                  </ul>
+                <li/>
+              </>
+            )
+          }
+          {
+            isEmpty(topics) ? "" : (
+              <>
+                <li class="text-info-emphasis"><span class="display-6">Topics</span>
+                  <ul class="mt-1 mb-3 list-disc">
+                    {topics.map((cat) => (
+                      <li class="list-item">
+                        <a href={`/blog/topics/${cat}`}>{startCase(cat)}</a>
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              </>
+            )
+          }
+          {
+            isEmpty(authors) ? "" : (
+              <>
+                <li class="text-info-emphasis"><span class="display-6">Authors</span>
+                  <ul class="mt-1 mb-3 list-disc">
+                    {authors.map((author) => (
+                      <li>
+                        <a href={`/blog/authors/${author.slug}`}>
+                          {author.data.name}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              </>
+            )
+          }
+          {
+            isEmpty(dates) ? "" : (
+              <>
+                <li class="text-info-emphasis"><span class="display-6">Dates</span>
+                  <ul class="mt-1 mb-3 list-disc">
+                    {dates.map((month) => (
+                      <li>
+                        <a href={`/blog/dates/${kebabCase(month)}`}>{month}</a>
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              </>
+            )
+          }
+        </ul>
+      </nav>
     </div>
   </ThemedSection>
 </Layout>
@@ -168,5 +174,13 @@ import ThemedSection from "../components/ThemedSection.astro";
 <style>
   div.fs-6 {
     line-height: 0.9em;
+  }
+
+  .list-disc {
+    list-style-type: disc;
+  }
+
+  .list-disc li::marker {
+    color: #FFFFFF;
   }
 </style>

--- a/astro/src/layouts/BlogLayout.astro
+++ b/astro/src/layouts/BlogLayout.astro
@@ -30,7 +30,6 @@ const {
   sidebar = false,
 } = Astro.props;
 const { title = blog.data.title, heading = undefined } = Astro.props;
-const isCustomHeading = !isNil(heading);
 const { blogs = [], authors = [], topics = [], dates = [] } = catalog;
 
 const blogAuthor = await getEntry(blog.data.author);
@@ -62,45 +61,35 @@ import ThemedSection from "../components/ThemedSection.astro";
   </Fragment>
   <ImageHeading image="blog" slot="header">
     <slot name="header">
-      {
-        isCustomHeading ?
-          <strong set:text={heading} />
-        : <Fragment>
-            <strong>Blog</strong> - {blog.data.title}
-          </Fragment>
-      }
+      <strong>Blog</strong>
     </slot>
   </ImageHeading>
   <ThemedSection style="tertiary" py={0}>
     <div class="d-flex gap-4">
-      <div class:list={[sidebar ? "d-none d-lg-block" : "col", "col-lg-9"]}>
-        {
-          isCustomHeading ?
-            <h2
-              class="display-4 border-bottom mb-3"
-              set:text={blog.data.title}
-            />
-          : ""
-        }
-        <div
-          class="d-flex flex-column flex-md-row justify-content-between mb-4"
-        >
-          <div>
-            <div class="d-block d-md-none display-6">{blogAuthor.data.name}</div
-            >
-            <div class="d-none d-md-block display-6">
-              <TeamVignette member={blogAuthor} />
-            </div>
-          </div>
-          <div
-            class="text-brand text-secondary-emphasis me-3"
-            set:text={published}
+        <article class:list={[sidebar ? "d-none d-lg-block" : "col", "col-lg-9"]}>
+          <h1
+                class="display-4 border-bottom mb-3"
+                set:text={blog.data.title}
           />
-        </div>
-        <article class="py-4 mb-4">
-          <Content />
+          <div
+            class="d-flex flex-column flex-md-row justify-content-between mb-4"
+          >
+            <div>
+              <div class="d-block d-md-none display-6">{blogAuthor.data.name}</div
+              >
+              <div class="d-none d-md-block display-6">
+                <TeamVignette member={blogAuthor} />
+              </div>
+            </div>
+            <div
+              class="text-brand text-primary-emphasis me-3"
+              set:text={published}
+            />
+          </div>
+          <div class="py-4 mb-4">
+            <Content />
+          </div>
         </article>
-      </div>
       <nav class:list={[sidebar ? "col" : "d-none d-lg-block", "col-lg-3"]} aria-label="Blog">
         <ul class="list-unstyled">
           {
@@ -176,11 +165,11 @@ import ThemedSection from "../components/ThemedSection.astro";
     line-height: 0.9em;
   }
 
-  .list-disc {
-    list-style-type: disc;
+  .vignette-name {
+    color: var(--bs-primary-text-emphasis);
   }
 
-  .list-disc li::marker {
-    color: #FFFFFF;
+  .list-disc {
+    list-style-type: disc;
   }
 </style>

--- a/astro/src/layouts/BlogLayout.astro
+++ b/astro/src/layouts/BlogLayout.astro
@@ -66,92 +66,88 @@ import ThemedSection from "../components/ThemedSection.astro";
   </ImageHeading>
   <ThemedSection style="tertiary" py={0}>
     <div class="d-flex gap-4">
-        <article class:list={[sidebar ? "d-none d-lg-block" : "col", "col-lg-9"]}>
-          <h1
-                class="display-4 border-bottom mb-3"
-                set:text={blog.data.title}
-          />
-          <div
-            class="d-flex flex-column flex-md-row justify-content-between mb-4"
-          >
-            <div>
-              <div class="d-block d-md-none display-6">{blogAuthor.data.name}</div
-              >
-              <div class="d-none d-md-block display-6">
-                <TeamVignette member={blogAuthor} />
-              </div>
+      <article class:list={[sidebar ? "d-none d-lg-block" : "col", "col-lg-9"]}>
+        <h1 class="display-4 border-bottom mb-3" set:text={blog.data.title} />
+        <div
+          class="d-flex flex-column flex-md-row justify-content-between mb-4"
+        >
+          <div>
+            <div class="d-block d-md-none display-6">{blogAuthor.data.name}</div
+            >
+            <div class="d-none d-md-block display-6">
+              <TeamVignette member={blogAuthor} />
             </div>
-            <div
-              class="text-brand text-primary-emphasis me-3"
-              set:text={published}
-            />
           </div>
-          <div class="py-4 mb-4">
-            <Content />
-          </div>
-        </article>
-      <nav class:list={[sidebar ? "col" : "d-none d-lg-block", "col-lg-3"]} aria-label="Blog">
+          <div
+            class="text-brand text-primary-emphasis me-3"
+            set:text={published}
+          />
+        </div>
+        <div class="py-4 mb-4">
+          <Content />
+        </div>
+      </article>
+      <nav
+        class:list={[sidebar ? "col" : "d-none d-lg-block", "col-lg-3"]}
+        aria-label="Blog"
+      >
         <ul class="list-unstyled">
           {
             isEmpty(blogs) ? "" : (
-              <>
-                <li class="text-info-emphasis"><span class="display-6">Blog Posts</span>
-                  <ul class="mt-1 mb-3 ps-4 list-disc">
-                    {blogs.map((b) => (
-                      <li>
-                        <a href={`/blog/${b.slug}`}>{b.data.title}</a>
-                      </li>
-                    ))}
-                  </ul>
-                <li/>
-              </>
+              <li class="text-info-emphasis">
+                <span class="display-6">Blog Posts</span>
+                <ul class="mt-1 mb-3 list-disc">
+                  {blogs.map((b) => (
+                    <li>
+                      <a href={`/blog/${b.slug}`}>{b.data.title}</a>
+                    </li>
+                  ))}
+                </ul>
+              </li>
             )
           }
           {
             isEmpty(topics) ? "" : (
-              <>
-                <li class="text-info-emphasis"><span class="display-6">Topics</span>
-                  <ul class="mt-1 mb-3 list-disc">
-                    {topics.map((cat) => (
-                      <li class="list-item">
-                        <a href={`/blog/topics/${cat}`}>{startCase(cat)}</a>
-                      </li>
-                    ))}
-                  </ul>
-                </li>
-              </>
+              <li class="text-info-emphasis">
+                <span class="display-6">Topics</span>
+                <ul class="mt-1 mb-3 list-disc">
+                  {topics.map((cat) => (
+                    <li class="list-item">
+                      <a href={`/blog/topics/${cat}`}>{startCase(cat)}</a>
+                    </li>
+                  ))}
+                </ul>
+              </li>
             )
           }
           {
             isEmpty(authors) ? "" : (
-              <>
-                <li class="text-info-emphasis"><span class="display-6">Authors</span>
-                  <ul class="mt-1 mb-3 list-disc">
-                    {authors.map((author) => (
-                      <li>
-                        <a href={`/blog/authors/${author.slug}`}>
-                          {author.data.name}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                </li>
-              </>
+              <li class="text-info-emphasis">
+                <span class="display-6">Authors</span>
+                <ul class="mt-1 mb-3 list-disc">
+                  {authors.map((author) => (
+                    <li>
+                      <a href={`/blog/authors/${author.slug}`}>
+                        {author.data.name}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </li>
             )
           }
           {
             isEmpty(dates) ? "" : (
-              <>
-                <li class="text-info-emphasis"><span class="display-6">Dates</span>
-                  <ul class="mt-1 mb-3 list-disc">
-                    {dates.map((month) => (
-                      <li>
-                        <a href={`/blog/dates/${kebabCase(month)}`}>{month}</a>
-                      </li>
-                    ))}
-                  </ul>
-                </li>
-              </>
+              <li class="text-info-emphasis">
+                <span class="display-6">Dates</span>
+                <ul class="mt-1 mb-3 list-disc">
+                  {dates.map((month) => (
+                    <li>
+                      <a href={`/blog/dates/${kebabCase(month)}`}>{month}</a>
+                    </li>
+                  ))}
+                </ul>
+              </li>
             )
           }
         </ul>

--- a/astro/src/styles/bootstrap.scss
+++ b/astro/src/styles/bootstrap.scss
@@ -301,6 +301,10 @@ $theme-colors-border-subtle-dark: map-merge($theme-colors-border-subtle-dark, $c
   font-family: $headings-font-family;
 }
 
+.list-disc li::marker {
+  color: $body-color;
+}
+
 textarea, input {
   border-width: 1.5px 1.5px;
   border-color: #000000;
@@ -377,6 +381,10 @@ img.profile-pic {
 
   .nav-link:hover {
     color: $body-tertiary-bg;
+  }
+
+  .list-disc li::marker {
+    color: #FFFFFF;
   }
 
   textarea, input {


### PR DESCRIPTION
I did some re-structuring of the blog page so that each post is now contained in its own `article` element. The navigational links are now on the side in a `nav` element. I changed the headings, "Blog Posts," "Topics," etc., to be list items, rather than headings. I hope that this is helpful, but I realize it also adds some more information for screen readers and am not sure if this is good or not.

Fixes #204 and #205