### PR TITLE
Center Mini Profiles on Staff Page

### DIFF
--- a/astro/src/pages/team/staff.astro
+++ b/astro/src/pages/team/staff.astro
@@ -37,7 +37,7 @@ const crumbs = [
     <ul class="list-inline text-center">
       {
         staff.map((member) => (
-          <li class="list-inline-item staff-list-item m-2 w-100">
+          <li class="list-inline-item staff-list-item my-2 m-md-2 w-100">
             <div class="text-start bg-body shadow-sm rounded-1 p-2 pt-3 fs-4">
               <TeamVignette
                 member={member}


### PR DESCRIPTION
Remove margin-x for small screen sizes, but keep margin as it was for other sizing. This allows the profiles to be centered on the screen for mobile views.

Fixes #215 