### PR TITLE
Make Team Contact Icons and Bitmoji Visible on Mobile Views

### DIFF
--- a/astro/src/components/SocialLinks.astro
+++ b/astro/src/components/SocialLinks.astro
@@ -20,7 +20,7 @@ interface Props {
   gap?: number;
 }
 
-const { links, adjective = "", gap = 2 } = Astro.props;
+const { links, adjective = "" } = Astro.props;
 const brandingThemes = {
   email: "primary",
 };
@@ -50,20 +50,22 @@ const socialLinks: Array<LinkConfig> = toPairs(links).map(([type, url]) => {
 {
   !isEmpty(socialLinks) && (
     <ul
-      class="list-inline hstack"
+      class="list-unstyled"
       aria-label={`${adjective} Communications and Social Media Links`}
     >
       {socialLinks.map((sl) => (
-        <li class="list-inline-item">
+        <li class="d-inline">
           <a
             href={sl.href}
-            class:list={["icon-link align-text-top", `text-${sl.theme}`]}
+            class:list={["align-text-top", `text-${sl.theme}`]}
             target="_blank"
             rel="noopener noreferrer"
           >
             <Icon
               name={sl.icon}
-              class={`bi m-${gap}`}
+              class="bi social-icon"
+              height="29"
+              width="29"
               role="img"
               aria-label={`${adjective} ${sl.service} ${sl.description}`}
             />
@@ -75,8 +77,8 @@ const socialLinks: Array<LinkConfig> = toPairs(links).map(([type, url]) => {
 }
 
 <style>
-  .icon-link > .bi {
-    height: 1.25em;
-    width: 1.25em;
+  .social-icon {
+    margin-bottom: 14.5px;
+    margin-inline: 14.5px;
   }
 </style>

--- a/astro/src/components/SocialLinks.astro
+++ b/astro/src/components/SocialLinks.astro
@@ -50,11 +50,11 @@ const socialLinks: Array<LinkConfig> = toPairs(links).map(([type, url]) => {
 {
   !isEmpty(socialLinks) && (
     <ul
-      class="list-unstyled d-inline-block"
+      class="list-unstyled d-inline-block mb-3"
       aria-label={`${adjective} Communications and Social Media Links`}
     >
       {socialLinks.map((sl) => (
-        <li class="d-inline">
+        <li class="d-inline mx-3">
           <a
             href={sl.href}
             class:list={["align-text-top", `text-${sl.theme}`]}
@@ -64,8 +64,6 @@ const socialLinks: Array<LinkConfig> = toPairs(links).map(([type, url]) => {
             <Icon
               name={sl.icon}
               class="bi social-icon"
-              height="29"
-              width="29"
               role="img"
               aria-label={`${adjective} ${sl.service} ${sl.description}`}
             />
@@ -78,7 +76,9 @@ const socialLinks: Array<LinkConfig> = toPairs(links).map(([type, url]) => {
 
 <style>
   .social-icon {
-    margin-bottom: 14.5px;
-    margin-inline: 14.5px;
+    width: 2rem;
+    height: 2rem;
+    min-height: 29px;
+    min-width: 29px;
   }
 </style>

--- a/astro/src/components/SocialLinks.astro
+++ b/astro/src/components/SocialLinks.astro
@@ -50,7 +50,7 @@ const socialLinks: Array<LinkConfig> = toPairs(links).map(([type, url]) => {
 {
   !isEmpty(socialLinks) && (
     <ul
-      class="list-unstyled"
+      class="list-unstyled d-inline-block"
       aria-label={`${adjective} Communications and Social Media Links`}
     >
       {socialLinks.map((sl) => (

--- a/astro/src/components/TeamMemberBio.astro
+++ b/astro/src/components/TeamMemberBio.astro
@@ -11,7 +11,7 @@ const { Content } = await member.render();
 
 <div class="border-bottom row justify-content-between">
   <div
-    class="col-md-9 col-lg-10 py-2 pe-1 d-flex justify-content-between align-items-end mb-0 mb-3-md"
+    class="col-md-9 py-2 pe-1 d-flex justify-content-between align-items-end mb-0 mb-3-md"
   >
     <TeamVignette
       member={member}
@@ -23,7 +23,7 @@ const { Content } = await member.render();
       size="lg"
     />
   </div>
-  <div class="col-md-3 col-lg-2 py-2 pe-3 pe-lg-3 pe-xl-4 ps-md-2 text-center text-md-end align-self-center">
+  <div class="col-md-3 py-2 pe-3 pe-lg-3 pe-xl-4 ps-md-2 text-center text-md-end align-self-center">
   {
     !isEmpty(links) && (
       <SocialLinks links={links} adjective={`${name}'s`} />

--- a/astro/src/components/TeamMemberBio.astro
+++ b/astro/src/components/TeamMemberBio.astro
@@ -11,11 +11,11 @@ const { Content } = await member.render();
 
 <div class="border-bottom row justify-content-between">
   <div
-    class="col-md-8 col-lg-6 team-bio py-2 pe-1 d-flex justify-content-between align-items-end mb-0 mb-3-md"
+    class="col-md-8 col-lg-6 py-2 pe-1 d-flex justify-content-between align-items-end mb-0 mb-3-md"
   >
     <TeamVignette
       member={member}
-      firstNameOnly={true}
+      firstNameOnly={false}
       highlightName={true}
       branded={true}
       valign="center"
@@ -36,7 +36,7 @@ const { Content } = await member.render();
 </div>
 
 <style is:global>
-  .team-bio .vignette-name {
+  .vignette-name {
     color: var(--bs-primary-text-emphasis);
     margin-bottom: 0.2rem;
   }

--- a/astro/src/components/TeamMemberBio.astro
+++ b/astro/src/components/TeamMemberBio.astro
@@ -11,7 +11,7 @@ const { Content } = await member.render();
 
 <div class="border-bottom row justify-content-between">
   <div
-    class="col-md-8 col-lg-6 py-2 pe-1 d-flex justify-content-between align-items-end mb-0 mb-3-md"
+    class="col-md-9 col-lg-10 py-2 pe-1 d-flex justify-content-between align-items-end mb-0 mb-3-md"
   >
     <TeamVignette
       member={member}
@@ -23,7 +23,7 @@ const { Content } = await member.render();
       size="lg"
     />
   </div>
-  <div class="col-md-4 py-2 pe-5 ps-4 text-center text-md-end align-self-center">
+  <div class="col-md-3 col-lg-2 py-2 pe-3 pe-lg-3 pe-xl-4 ps-md-2 text-center text-md-end align-self-center">
   {
     !isEmpty(links) && (
       <SocialLinks links={links} adjective={`${name}'s`} />

--- a/astro/src/components/TeamMemberBio.astro
+++ b/astro/src/components/TeamMemberBio.astro
@@ -9,26 +9,31 @@ const { name, links } = member.data;
 const { Content } = await member.render();
 ---
 
-<div
-  class="team-bio py-2 pe-1 d-flex justify-content-between align-items-end border-bottom mb-3"
->
-  <TeamVignette
-    member={member}
-    highlightName={true}
-    branded={true}
-    element="h2"
-    valign="end"
-    responsive={true}
-  />
+<div class="border-bottom row justify-content-between">
+  <div
+    class="col-md-8 col-lg-6 team-bio py-2 pe-1 d-flex justify-content-between align-items-end mb-0 mb-3-md"
+  >
+    <TeamVignette
+      member={member}
+      firstNameOnly={true}
+      highlightName={true}
+      branded={true}
+      valign="center"
+      element = "h2"
+      size="lg"
+    />
+  </div>
+  <div class="col-md-4 py-2 pe-5 ps-4 text-center text-md-end align-self-center">
   {
     !isEmpty(links) && (
-      <div class="d-none d-md-block display-5">
-        <SocialLinks links={links} adjective={`${name}'s`} />
-      </div>
+      <SocialLinks links={links} adjective={`${name}'s`} />
     )
   }
+  </div>
 </div>
-<Content />
+<div class="p-2">
+  <Content />
+</div>
 
 <style is:global>
   .team-bio .vignette-name {

--- a/astro/src/components/TeamMemberBio.astro
+++ b/astro/src/components/TeamMemberBio.astro
@@ -19,16 +19,14 @@ const { Content } = await member.render();
       highlightName={true}
       branded={true}
       valign="center"
-      element = "h2"
+      element="h2"
       size="lg"
     />
   </div>
-  <div class="col-md-3 py-2 pe-3 pe-lg-3 pe-xl-4 ps-md-2 text-center text-md-end align-self-center">
-  {
-    !isEmpty(links) && (
-      <SocialLinks links={links} adjective={`${name}'s`} />
-    )
-  }
+  <div
+    class="col-md-3 py-2 pe-3 pe-lg-3 pe-xl-4 ps-md-2 text-center text-md-end align-self-center"
+  >
+    {!isEmpty(links) && <SocialLinks links={links} adjective={`${name}'s`} />}
   </div>
 </div>
 <div class="p-2">

--- a/astro/src/components/TeamVignette.astro
+++ b/astro/src/components/TeamVignette.astro
@@ -51,7 +51,7 @@ const NameTag = element;
     `gap-${size == "lg" ? "2" : "1"}`,
   ]}
 >
-  <div class:list={["flex-fill text-start", branded && "text-brand"]}>
+  <div class:list={["flex-fill text-start me-2", branded && "text-brand"]}>
     <NameTag class="vignette-name" set:html={displayName} />
     <div class="vignette-title" set:html={title} />
   </div>

--- a/astro/src/components/TeamVignette.astro
+++ b/astro/src/components/TeamVignette.astro
@@ -51,7 +51,12 @@ const NameTag = element;
     `gap-${size == "lg" ? "2" : "1"}`,
   ]}
 >
-  <div class:list={["flex-fill text-start me-2 me-sm-1 me-md-0", branded && "text-brand"]}>
+  <div
+    class:list={[
+      "flex-fill text-start me-2 me-sm-1 me-md-0",
+      branded && "text-brand",
+    ]}
+  >
     <NameTag class="vignette-name" set:html={displayName} />
     <div class="vignette-title" set:html={title} />
   </div>

--- a/astro/src/components/TeamVignette.astro
+++ b/astro/src/components/TeamVignette.astro
@@ -51,7 +51,7 @@ const NameTag = element;
     `gap-${size == "lg" ? "2" : "1"}`,
   ]}
 >
-  <div class:list={["flex-fill text-start me-2", branded && "text-brand"]}>
+  <div class:list={["flex-fill text-start me-2 me-sm-1 me-md-0", branded && "text-brand"]}>
     <NameTag class="vignette-name" set:html={displayName} />
     <div class="vignette-title" set:html={title} />
   </div>

--- a/astro/src/pages/team/[tag].astro
+++ b/astro/src/pages/team/[tag].astro
@@ -58,8 +58,8 @@ const crumbs = [
     <ul class="list-group">
       {
         teamMembers.map((sm) => (
-          <li class="list-inline-item m-2 w-100">
-            <div class="text-start bg-body shadow-sm rounded-1 p-2 pt-3 fs-4">
+          <li class="list-inline-item my-2 w-100">
+            <div class="text-start bg-body shadow-sm rounded-1 p-2 pt-2 fs-4">
               <TeamMemberBio member={sm} />
             </div>
           </li>

--- a/astro/src/pages/team/[tag].astro
+++ b/astro/src/pages/team/[tag].astro
@@ -59,7 +59,7 @@ const crumbs = [
       {
         teamMembers.map((sm) => (
           <li class="list-inline-item my-2 w-100">
-            <div class="text-start bg-body shadow-sm rounded-1 p-2 pt-2 fs-4">
+            <div class="text-start p-2 pt-2 fs-4">
               <TeamMemberBio member={sm} />
             </div>
           </li>

--- a/astro/src/pages/team/[tag].astro
+++ b/astro/src/pages/team/[tag].astro
@@ -27,7 +27,6 @@ export async function getStaticPaths() {
 import ImageHeading from "../../components/ImageHeading.astro";
 import Layout from "../../layouts/Layout.astro";
 import TeamMemberBio from "../../components/TeamMemberBio.astro";
-// import TeamHeading from "../../components/TeamHeading.astro";
 import ThemedSection from "../../components/ThemedSection.astro";
 
 import { sortBy } from "lodash-es";

--- a/astro/src/pages/team/[tag].astro
+++ b/astro/src/pages/team/[tag].astro
@@ -59,7 +59,7 @@ const crumbs = [
       {
         teamMembers.map((sm) => (
           <li class="list-inline-item my-2 w-100">
-            <div class="text-start p-2 pt-2 fs-4">
+            <div class="text-start p-1 p-lg-2 pt-2 fs-4">
               <TeamMemberBio member={sm} />
             </div>
           </li>

--- a/astro/src/pages/team/[tag].astro
+++ b/astro/src/pages/team/[tag].astro
@@ -27,7 +27,7 @@ export async function getStaticPaths() {
 import ImageHeading from "../../components/ImageHeading.astro";
 import Layout from "../../layouts/Layout.astro";
 import TeamMemberBio from "../../components/TeamMemberBio.astro";
-import TeamHeading from "../../components/TeamHeading.astro";
+// import TeamHeading from "../../components/TeamHeading.astro";
 import ThemedSection from "../../components/ThemedSection.astro";
 
 import { sortBy } from "lodash-es";
@@ -58,11 +58,26 @@ const crumbs = [
     <ul class="list-group">
       {
         teamMembers.map((sm) => (
-          <li class="d-block mb-5">
-            <TeamMemberBio member={sm} />
+          <li class="list-inline-item m-2 w-100">
+            <div class="text-start bg-body shadow-sm rounded-1 p-2 pt-3 fs-4">
+              <TeamMemberBio member={sm} />
+            </div>
           </li>
         ))
       }
     </ul>
   </ThemedSection>
 </Layout>
+
+<style is:global>
+  .staff-list-item {
+    max-width: 18rem;
+  }
+  .staff-list-item .vignette-name {
+    color: var(--bs-primary-text-emphasis);
+    margin-bottom: -0.1em;
+  }
+  .staff-list-item .vignette-title {
+    line-height: 1.1em;
+  }
+</style>


### PR DESCRIPTION
As the screen size decreases, the Bitmoji for each team member remains visible, as do the contact icon(s). The contact icons now wrap to be center under each member's picture and name/title.

@brian-montgomery, the icons have been resized using relative units/spacing, and I fixed the issue of how the heading text was wrapping at different screen sizes.

Fixes #179