### PR TITLE
Update Social Icons to Use Relative Sizing & Have Better Focus Indicator

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -103,7 +103,7 @@ const Socials = [
               Socials.map(({ icon, href, className, name }) => (
                 <li class="d-inline-block m-3">
                   <a
-                    class="d-inline-block link-light"
+                    class="d-inline-block link-light social-link"
                     href={href}
                     target="_blank"
                     rel="noopener noreferrer"

--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -101,7 +101,7 @@ const Socials = [
           <ul class="ps-0 mb-0">
             {
               Socials.map(({ icon, href, className, name }) => (
-                <li class="d-inline-block">
+                <li class="d-inline-block m-3">
                   <a
                     class="d-inline-block link-light"
                     href={href}
@@ -112,8 +112,8 @@ const Socials = [
                       name={icon}
                       class={className}
                       class="social-icon"
-                      height="29"
-                      width="29"
+                      height="2rem"
+                      width="2rem"
                       role="img"
                       aria-label={name}
                     />
@@ -153,7 +153,8 @@ const Socials = [
   }
 
   .social-icon {
-    margin: 14.5px;
+    min-height: 29px;
+    min-width: 29px;
   }
 
   .legal-footer {

--- a/astro/src/components/SocialLinks.astro
+++ b/astro/src/components/SocialLinks.astro
@@ -57,7 +57,7 @@ const socialLinks: Array<LinkConfig> = toPairs(links).map(([type, url]) => {
         <li class="d-inline mx-3">
           <a
             href={sl.href}
-            class:list={["align-text-top", `text-${sl.theme}`]}
+            class:list={["align-text-top social-link", `text-${sl.theme}`]}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/astro/src/styles/bootstrap.scss
+++ b/astro/src/styles/bootstrap.scss
@@ -275,6 +275,10 @@ $theme-colors-border-subtle-dark: map-merge($theme-colors-border-subtle-dark, $c
   outline-offset: -0.15em;
 }
 
+.social-link:focus-visible {
+  outline-offset: 0.15em;
+}
+
 .btn:focus-visible {
   outline: 3px dashed $primary;
   outline-offset: 0.25rem;


### PR DESCRIPTION
Adjust footer social icon sizing to be similar to Leadership social icons. Space the focus indicator outline a little better around each of these social icons.