### PR TITLE
Update Volunteer page to use "Evaluations Team" wording.

### DIFF
--- a/astro/src/pages/volunteer.astro
+++ b/astro/src/pages/volunteer.astro
@@ -144,11 +144,11 @@ import heroBg from "../images/colored-hero/hands-together.png";
       </div>
       <div class="col-md-9 col-lg-5">
         <div class="card mb-3 shadow team-card">
-          <h3 class="display-5 card-header">Evaluation Team</h3>
+          <h3 class="display-5 card-header">Evaluations Team</h3>
           <div class="card-body">
             <p class="card-text">
               <span class="fw-bold">Description:</span>
-              The Evaluation Team tests the web site accessibility of small organizations
+              The Evaluations Team tests the web site accessibility of small organizations
               that can't afford accessibility audits. This allows professionals who
               are learning about accessibility to practice and get feedback while
               helping smaller community organizations. We ask that participants review
@@ -160,7 +160,7 @@ import heroBg from "../images/colored-hero/hands-together.png";
             </p>
             <p><span class="fw-bold">Team Leader:</span> Rachael</p>
             <p>
-              For more info on the Evaluation&nbsp;Team, <a
+              For more info on the Evaluations&nbsp;Team, <a
                 class="volunteer-link"
                 href="mailto:rachael@accessiblecommunity.org"
                 >email&nbsp;Rachael</a


### PR DESCRIPTION
On the Volunteer page, it currently says "Evaluation Team," so this is now changing to use the plural, "Evaluations."