### PR TITLE
Center staff profiles for small screens.

### DIFF
--- a/astro/src/pages/team/staff.astro
+++ b/astro/src/pages/team/staff.astro
@@ -72,7 +72,7 @@ const crumbs = [
       teams.map(({name, team, members}) => {
         return (
           <h2 class="mt-5 ms-3"> {name} </h2>
-          <ul class="list-inline-block text-center">
+          <ul class="list-inline-block text-center px-2 px-md-4">
           {
             members.map((member) => {
               return (


### PR DESCRIPTION
Adjust inline padding for staff `ul` elements so profiles are centered on the page for smaller screens.