### PR TITLE
Add inline padding for "Communities are people" section.

### DIFF
--- a/astro/src/pages/about/mission.astro
+++ b/astro/src/pages/about/mission.astro
@@ -147,7 +147,7 @@ import partnerImage from "../../images/np_Business-partners-discussing-work-arra
       >
         <Quote q="loneliness" />
       </ThemedBox>
-      <div class="text-primary col col-lg-8 col-xl-7">
+      <div class="text-primary col col-lg-8 col-xl-7 px-4">
         <p class="lead">
           <ExternalLink
             href="https://www.cdc.gov/ncbddd/disabilityandhealth/infographic-disability-impacts-all.html"

--- a/astro/src/pages/about/mission.astro
+++ b/astro/src/pages/about/mission.astro
@@ -143,7 +143,7 @@ import partnerImage from "../../images/np_Business-partners-discussing-work-arra
       <ThemedBox
         theme="info"
         style="subtle"
-        class="my-auto col col-lg-3 col-xl-3 rounded shadow-sm"
+        class="mx-4 my-auto col col-lg-3 col-xl-3 rounded shadow-sm"
       >
         <Quote q="loneliness" />
       </ThemedBox>


### PR DESCRIPTION
This padding seems to have been removed for some reason, so I'm adding it in.