### PR TITLE
Use higher-contrast color for <code> elements in dark mode.

### DIFF
--- a/astro/src/styles/bootstrap.scss
+++ b/astro/src/styles/bootstrap.scss
@@ -405,6 +405,10 @@ svg[data-icon="loca11y-logo"].unpad {
     border-color: #FFFFFF;
   }
 
+  code {
+    color: #EAB3E8;
+  }
+
   .bi {  // blue-30
     filter: brightness(0) saturate(100%) invert(71%) sepia(19%) saturate(851%) hue-rotate(172deg) brightness(91%) contrast(95%);
   }

--- a/astro/src/styles/bootstrap.scss
+++ b/astro/src/styles/bootstrap.scss
@@ -109,7 +109,7 @@ $btn-hover-border-shade-amount:   30%;
 $btn-hover-border-tint-amount:    20%;
 
 $code-color:                  #590455;
-// $code-color-dark:             tint-color($code-color, 40%) !default;
+$code-color-dark:             #EAB3E8;
 
 $container-padding-x:  3rem;
 
@@ -403,10 +403,6 @@ svg[data-icon="loca11y-logo"].unpad {
 
   textarea, input {
     border-color: #FFFFFF;
-  }
-
-  code {
-    color: #EAB3E8;
   }
 
   .bi {  // blue-30


### PR DESCRIPTION
Fixes #245 