### PR TITLE
chore: remove duplicate donate header

### DIFF
--- a/astro/src/components/ERHeader.astro
+++ b/astro/src/components/ERHeader.astro
@@ -197,7 +197,6 @@ const breadCrumbs: Breadcrumbs =
                     ><a class="dropdown-item" href="/volunteer">Volunteer</a
                     ></li
                   >
-                  <li><a class="dropdown-item" href="/donate">Donate</a></li>
                   <!-- TODO: Hiding the sponsor page until it's done. -->
                   <!-- <li><a class="dropdown-item" href="/join-us/sponsor">Sponsor</a></li> -->
                 </ul>
@@ -354,7 +353,6 @@ const breadCrumbs: Breadcrumbs =
           >
           <ul class="dropdown-menu px-15 pb-1">
             <li><a class="dropdown-item" href="/volunteer">Volunteer</a></li>
-            <li><a class="dropdown-item" href="/donate">Donate</a></li>
             <!-- TODO: Hiding the sponsor page until it's done. -->
             <!-- <li><a class="dropdown-item" href="/join-us/sponsor">Sponsor</a></li> -->
           </ul>

--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -193,7 +193,6 @@ const breadCrumbs: Breadcrumbs =
           >
           <ul class="dropdown-menu px-15 pb-1">
             <li><a class="dropdown-item" href="/volunteer">Volunteer</a></li>
-            <li><a class="dropdown-item" href="/donate">Donate</a></li>
             <!-- TODO: Hiding the sponsor page until it's done. -->
             <!-- <li><a class="dropdown-item" href="/join-us/sponsor">Sponsor</a></li> -->
           </ul>


### PR DESCRIPTION
**Problem:**

Duplicate donate header in the top navigation.

**Solution:**

Remove the one from the dropdown. Leave the button.