### PR TITLE
fix: update heading 1

### DIFF
--- a/astro/src/pages/services/escape-room/index.astro
+++ b/astro/src/pages/services/escape-room/index.astro
@@ -32,8 +32,7 @@ import woodenPuzzles from "src/images/escape-room/wooden-puzzles.png";
       class="d-flex flex-column flex-lg-row gap-4 py-3 justify-content-lg-center align-items-center"
     >
       <div class="col col-lg-6 col-xl-7 text-light">
-        <h1 class="visually-hidden" set:text={title}></h1>
-        <p class="display-2">A fun and accessible team-building activity.</p>
+        <h1 class="text-white display-2">A fun and accessible team-building activity.</h1>
         <p class="lead">
           Where teams of 3-10 people, with or without disabilities, try to solve
           puzzles to reach an objective while learning about accessibility.


### PR DESCRIPTION
Problem:

Heading 1 on escape room homepage didn't match visual text.

Solution:

Update the visual text to be the heading 1.