### PR TITLE
Prevent breadcrumb separators from being announced by screen readers

### DIFF
--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -67,6 +67,7 @@ const breadCrumbs: Breadcrumbs =
               { branded ? (<Branding set:text={name} />) : name }
             </a>
           </li>
+          <span aria-hidden="true">&nbsp/&nbsp</span>
         ))
       }
       <li class="breadcrumb-item active" aria-current="page">

--- a/astro/src/components/HeroWithBreadcrumbs.astro
+++ b/astro/src/components/HeroWithBreadcrumbs.astro
@@ -59,6 +59,7 @@ import Branding from "./Branding.astro";
               { branded ? (<Branding set:text={name} />) : name }
             </a>
           </li>
+          <span aria-hidden="true">&nbsp/&nbsp</span>
         ))
       }
       <li class:list={['breadcrumb-item active px-1', shade && `bg-${theme} bg-opacity-50`]} aria-current="page">

--- a/astro/src/styles/bootstrap.scss
+++ b/astro/src/styles/bootstrap.scss
@@ -100,6 +100,7 @@ $nav-link-focus-box-shadow:         none;
 $breadcrumb-font-size:              0.9em;
 $breadcrumb-margin-bottom:          0;
 $breadcrumb-active-color:           $ac-navy;
+$breadcrumb-divider:                none;
 
 //************
 //* Dropdowns


### PR DESCRIPTION
Remove default breadcrumb pseudo-element and replace it with a span that uses "aria-hidden" for slash character. Fixes #405 