### PR TITLE
Ensure user must select an option from form selects in order for successful submission of both mutua11y forms.

### DIFF
--- a/astro/src/pages/mutua11y/mentor-registration.astro
+++ b/astro/src/pages/mutua11y/mentor-registration.astro
@@ -146,7 +146,7 @@ import ThemedSection from "@components/ThemedSection.astro";
               aria-label="Region selection"
               required
             >
-              <option selected disabled>
+              <option value="" selected disabled>
                 Select the region you most frequently live and work in...
               </option>
               { regions.map((region) => <option value={region} set:text={region} />) }
@@ -164,7 +164,7 @@ import ThemedSection from "@components/ThemedSection.astro";
               aria-label="Timezone selection"
               required
             >
-              <option selected disabled aria-disabled="false">Select the timezone you live in...</option>
+              <option value="" selected disabled aria-disabled="false">Select the timezone you live in...</option>
               { timeZones.map((tz) => <option value={tz} set:text={tz} />) }
             </select>
           </fieldset>
@@ -332,7 +332,7 @@ import ThemedSection from "@components/ThemedSection.astro";
               id="experienceField"
               required
             >
-              <option selected disabled>
+              <option value="" selected disabled>
                 Select the number of years that best fits your experience...
               </option>
               {experienceLevels.map((tz) => <option value={tz}>{tz}</option>)}

--- a/astro/src/pages/mutua11y/protege-registration.astro
+++ b/astro/src/pages/mutua11y/protege-registration.astro
@@ -144,7 +144,7 @@ import ThemedSection from "@components/ThemedSection.astro";
               aria-label="Region selection"
               required
             >
-              <option selected disabled>
+              <option value="" selected disabled>
                 Select the region you most frequently live and work in...
               </option>
               { regions.map((region) => <option value={region} set:text={region} />) }
@@ -162,7 +162,7 @@ import ThemedSection from "@components/ThemedSection.astro";
               aria-label="Timezone selection"
               required
             >
-              <option selected disabled aria-disabled="false">Select the timezone you live in...</option>
+              <option value="" selected disabled aria-disabled="false">Select the timezone you live in...</option>
               { timeZones.map((tz) => <option value={tz} set:text={tz} />) }
             </select>
           </fieldset>


### PR DESCRIPTION
Fixes #45
Also updates both mutua11y forms where this behavior was occurring for other elements.

Provide value="" for `option` elements so that required dropdowns will not allow automatic form submission without choosing an option.