### PR TITLE
Issue #536: Fix Blog Authors showing incorrectly

### DIFF
--- a/astro/src/layouts/BlogLayout.astro
+++ b/astro/src/layouts/BlogLayout.astro
@@ -1,6 +1,6 @@
 ---
 import { getEntry, render } from "astro:content";
-import { getBlogCatalog, type BlogCatalog } from "@lib/blog";
+import { formatAuthorName, getBlogCatalog, type BlogCatalog } from "@lib/blog";
 import { getOpenGraphImageData } from "@lib/og-image";
 import { isEmpty, kebabCase, startCase } from "lodash-es";
 
@@ -53,12 +53,6 @@ const metadata: PageMetadata = {
   ),
 };
 
-function formatName(author) {
-  const { name, cited = undefined } = author.data;
-  const { first, middle, last } = cited || name;
-  return [first, middle, last].filter((n) => n).join(" ");
-}
-
 const { Content } = await render(blog);
 
 import components from "../lib/mdx";
@@ -75,7 +69,7 @@ import ThemedSection from "@components/ThemedSection.astro";
       property="article:published_time"
       content={blog.data.published.toISOString()}
     />
-    <meta property="article:author" content={formatName(blogAuthor)} />
+    <meta property="article:author" content={formatAuthorName(blogAuthor)} />
     <meta property="article:section" content="Accessibility" />
     {blog.data.tags.map((tag) => <meta property="article:tag" content={tag} />)}
   </Fragment>
@@ -154,7 +148,7 @@ import ThemedSection from "@components/ThemedSection.astro";
                   {authors.map((author) => (
                     <li>
                       <a href={`/blog/authors/${author.id}`}>
-                        {formatName(author)}
+                        {formatAuthorName(author)}
                       </a>
                     </li>
                   ))}

--- a/astro/src/lib/blog.ts
+++ b/astro/src/lib/blog.ts
@@ -1,6 +1,12 @@
 import { getCollection, getEntries, type CollectionEntry } from "astro:content";
 import { isEmpty, isNil, reverse, sortBy, uniqBy } from "lodash-es";
 
+export function formatAuthorName(author: CollectionEntry<"staff">): string {
+  const { name, cited } = author.data;
+  const { first, middle, last } = cited || name;
+  return [first, middle, last].filter((n) => n).join(" ");
+}
+
 export async function getBlogAuthors(
   blogs?,
 ): Promise<Array<CollectionEntry<"staff">>> {

--- a/astro/src/pages/blog/authors/[...slug].astro
+++ b/astro/src/pages/blog/authors/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from "astro:content";
-import { getBlogAuthors, orderByRecent } from "../../../lib/blog";
+import { formatAuthorName, getBlogAuthors, orderByRecent } from "../../../lib/blog";
 import type { Breadcrumbs } from "@lib/types";
 import type { CollectionEntry } from "astro:content";
 
@@ -43,13 +43,13 @@ import BlogLayout from "../../../layouts/BlogLayout.astro";
 ---
 
 <BlogLayout
-  title={`Blogs by ${author.data.name}`}
+  title={`Blogs by ${formatAuthorName(author)}`}
   {crumbs}
   blog={orderedBlogs[0]}
   catalog={{ blogs: orderedBlogs }}
   sidebar={true}
 >
   <Fragment slot="header">
-    <strong>Blogs</strong> by {author.data.name}
+    <strong>Blogs</strong> by {formatAuthorName(author)}
   </Fragment>
 </BlogLayout>

--- a/astro/src/pages/blog/authors/index.astro
+++ b/astro/src/pages/blog/authors/index.astro
@@ -1,5 +1,5 @@
 ---
-import { getBlogAuthors } from "../../../lib/blog";
+import { formatAuthorName, getBlogAuthors } from "../../../lib/blog";
 
 const authors = await getBlogAuthors();
 const title = "Authors";
@@ -29,7 +29,7 @@ import ThemedSection from "../../../components/ThemedSection.astro";
       {
         authors.map((author) => (
           <li>
-            <a href={`/blog/authors/${author.id}`}>{author.data.name}</a>
+            <a href={`/blog/authors/${author.id}`}>{formatAuthorName(author)}</a>
           </li>
         ))
       }


### PR DESCRIPTION
## Fixes

* #536 


## Description

Select the correct slice of the author data to display the name correctly.
Created a shared function

## Screenshots

### Blogs by author page
url: https://accessiblecommunity.org/blog/authors/

| Before | After|
|----|----|
| <img width="500" alt="production screenshot where the list of authors are displayed as [object Object] " src="https://github.com/user-attachments/assets/39800de4-1f7f-47b3-9082-2fe421bb6eb4" /> | <img width="500"  alt="local version where the list of authors are displayed correctly" src="https://github.com/user-attachments/assets/993d9b16-4407-4c8f-8c80-f41ada1ff635" />|

Screenshot from preview link - https://deploy-preview-549--accessiblecommunity.netlify.app/blog/authors/
<img width="827" height="730" alt="screenshot from deployed preview showing the list of authors displayed correctly" src="https://github.com/user-attachments/assets/df7f5643-7969-419b-a66b-d789589b0a01" />

### Blog Author Page
url: https://accessiblecommunity.org/blog/authors/rachael-bradley-montgomery/

* Breadcrums
*  Title

| Before | After|
|----|----|
| <img width="857" height="554" alt="production author page where the breadcrumbs and title display [object Object] instead of the author name" src="https://github.com/user-attachments/assets/3a8b8739-4187-45af-b7d0-bc5f5c279ad0" />|<img width="1207" height="544" alt="loca version where the author is correctly displayed" src="https://github.com/user-attachments/assets/db674d57-1bb7-4c51-a4e5-8e90fc360d82" />|




Screenshot from preview link - https://deploy-preview-549--accessiblecommunity.netlify.app/blog/authors/rachael-bradley-montgomery/
<img width="1161" height="574" alt="screenshot from the deployed preview showing the breadcrumbs and title correctly displaying the author name" src="https://github.com/user-attachments/assets/88953176-2643-46e2-b69d-f34608f5d2f9" />



---

> [!NOTE]
> Additional places where author data is formatted.  See below for code snippets
> * astro/src/pages/team/previous.astro - line 37 - [Link to code](https://github.com/accessiblecommunity/accessiblecommunity.github.io/blob/main/astro/src/pages/team/previous.astro#L37) - This could use the formatAuthorName. 
> * astro/src/components/TeamVignette.astro - line 58 - [Link to code](https://github.com/accessiblecommunity/accessiblecommunity.github.io/blob/main/astro/src/pages/team/previous.astro#L37) - This is similar but has different logic and formatting

### New function

```js
export function formatAuthorName(author: CollectionEntry<"staff">): string {
  const { name, cited } = author.data;
  const { first, middle, last } = cited || name;
  return [first, middle, last].filter((n) => n).join(" ");
}
```

### TeamVignette - getDisplayName

```js
function getDisplayName({ first, middle, last }: Names) {
  if (highlightName) first = `<strong>${first}</strong>`;
  if (firstNameOnly) return first;
  return [first, middle, last].filter((n) => n).join(" ");
}
```
### previous.astro - getFullName

```js
function getFullName({first, middle, last}: CollectionEntry<"staff">["data"]["name"]) {
  return [first, middle, last].filter((n) => n).join(" ");
}
```

