### PR TITLE
Add helpful instructions for mutua11y forms' time zone question.

### DIFF
--- a/astro/src/pages/mutua11y/mentor-registration.astro
+++ b/astro/src/pages/mutua11y/mentor-registration.astro
@@ -162,13 +162,13 @@ import ThemedSection from "@components/ThemedSection.astro";
               class="form-select mb-2"
               name="Timezone"
               aria-label="Timezone selection"
-              aria-describedby="regionHelpLink"
+              aria-describedby="timezoneHelpLink"
               required
             >
               <option value="" selected disabled aria-disabled="false">Select the timezone you live in...</option>
               { timeZones.map((tz) => <option value={tz} set:text={tz} />) }
             </select>
-            <div id="regionHelpLink" class="form-text small">
+            <div id="timezoneHelpLink" class="form-text small">
               Not sure what your time zone is?
               <a href="https://time.is/" target="_blank" rel="noopener noreferrer">
                 Find your current time zone and UTC offset.

--- a/astro/src/pages/mutua11y/mentor-registration.astro
+++ b/astro/src/pages/mutua11y/mentor-registration.astro
@@ -135,7 +135,7 @@ import ThemedSection from "@components/ThemedSection.astro";
             We will use this information to try and best match your geographic region, timezone and spoken languages whenever possible.
           </p>
         </Column>
-        <Column noDefault md="6" class="mb-3">
+        <Column noDefault lg="6" class="mb-3">
           <fieldset>
             <legend class="mb-1 fs-6 required-field">
               What region do you primarily live and work in? <span class="asterisk" aria-hidden="true"></span>
@@ -153,7 +153,7 @@ import ThemedSection from "@components/ThemedSection.astro";
             </select>
           </fieldset>
         </Column>
-        <Column noDefault md="6" class="mb-3">
+        <Column noDefault lg="6" class="mb-3">
           <fieldset>
             <legend class="mb-1 fs-6 required-field">
               What timezone do you live in? <span class="asterisk" aria-hidden="true"></span>

--- a/astro/src/pages/mutua11y/mentor-registration.astro
+++ b/astro/src/pages/mutua11y/mentor-registration.astro
@@ -158,7 +158,9 @@ import ThemedSection from "@components/ThemedSection.astro";
         <Column noDefault lg="6" class="mb-3">
           <fieldset>
             <legend class="mb-1 fs-6 required-field">
-              What time zone do you live in? <span class="asterisk" aria-hidden="true"></span>
+              What time zone do you live in?
+              <span class="asterisk" aria-hidden="true"></span>
+              <span class="form-text">(UTC stands for Universal Coordinated Time)</span>
             </legend>
             <select
               class="form-select mb-2"
@@ -173,7 +175,7 @@ import ThemedSection from "@components/ThemedSection.astro";
             <div id="timeZoneHelpLink" class="form-text small">
               Not sure what your time zone is?
               <ExternalLink href="https://time.is/your_time_zone">
-                Find your current time zone and UTC offset
+                Find your time zone and UTC offset
               </ExternalLink>.
             </div>
           </fieldset>

--- a/astro/src/pages/mutua11y/mentor-registration.astro
+++ b/astro/src/pages/mutua11y/mentor-registration.astro
@@ -31,6 +31,7 @@ const crumbs: Breadcrumbs = [
 
 import Branding from "@components/Branding.astro";
 import Column from "@components/Column.astro";
+import ExternalLink from "@components/ExternalLink.astro";
 import GoogleForm from "@components/forms/GoogleForm.astro";
 import ImageHeading from "@components/ImageHeading.astro";
 import Layout from "src/layouts/Layout.astro";
@@ -170,9 +171,9 @@ import ThemedSection from "@components/ThemedSection.astro";
             </select>
             <div id="timezoneHelpLink" class="form-text small">
               Not sure what your time zone is?
-              <a href="https://time.is/" target="_blank" rel="noopener noreferrer">
-                Find your current time zone and UTC offset.
-              </a>
+              <ExternalLink href="https://time.is/">
+                Find your current time zone and UTC offset
+              </ExternalLink>.
             </div>
           </fieldset>
         </Column>

--- a/astro/src/pages/mutua11y/mentor-registration.astro
+++ b/astro/src/pages/mutua11y/mentor-registration.astro
@@ -134,7 +134,7 @@ import ThemedSection from "@components/ThemedSection.astro";
         <Column noDefault md="12" class="mb-3">
           <h3 class="display-5">Your location and language information</h3>
           <p class="form-text">
-            We will use this information to try and best match your geographic region, timezone and spoken languages whenever possible.
+            We will use this information to try and best match your geographic region, time zone and spoken languages whenever possible.
           </p>
         </Column>
         <Column noDefault lg="6" class="mb-3">
@@ -158,21 +158,21 @@ import ThemedSection from "@components/ThemedSection.astro";
         <Column noDefault lg="6" class="mb-3">
           <fieldset>
             <legend class="mb-1 fs-6 required-field">
-              What timezone do you live in? <span class="asterisk" aria-hidden="true"></span>
+              What time zone do you live in? <span class="asterisk" aria-hidden="true"></span>
             </legend>
             <select
               class="form-select mb-2"
-              name="Timezone"
-              aria-label="Timezone selection"
-              aria-describedby="timezoneHelpLink"
+              name="TimeZone"
+              aria-label="Time zone selection"
+              aria-describedby="timeZoneHelpLink"
               required
             >
-              <option value="" selected disabled aria-disabled="false">Select the timezone you live in...</option>
+              <option value="" selected disabled aria-disabled="false">Select the time zone you live in...</option>
               { timeZones.map((tz) => <option value={tz} set:text={tz} />) }
             </select>
-            <div id="timezoneHelpLink" class="form-text small">
+            <div id="timeZoneHelpLink" class="form-text small">
               Not sure what your time zone is?
-              <ExternalLink href="https://time.is/">
+              <ExternalLink href="https://time.is/your_time_zone">
                 Find your current time zone and UTC offset
               </ExternalLink>.
             </div>

--- a/astro/src/pages/mutua11y/mentor-registration.astro
+++ b/astro/src/pages/mutua11y/mentor-registration.astro
@@ -162,11 +162,18 @@ import ThemedSection from "@components/ThemedSection.astro";
               class="form-select mb-2"
               name="Timezone"
               aria-label="Timezone selection"
+              aria-describedby="regionHelpLink"
               required
             >
               <option value="" selected disabled aria-disabled="false">Select the timezone you live in...</option>
               { timeZones.map((tz) => <option value={tz} set:text={tz} />) }
             </select>
+            <div id="regionHelpLink" class="form-text small">
+              Not sure what your time zone is?
+              <a href="https://time.is/" target="_blank" rel="noopener noreferrer">
+                Find your current time zone and UTC offset.
+              </a>
+            </div>
           </fieldset>
         </Column>
         <div class="col-12 mb-3">

--- a/astro/src/pages/mutua11y/protege-registration.astro
+++ b/astro/src/pages/mutua11y/protege-registration.astro
@@ -29,6 +29,7 @@ const crumbs: Breadcrumbs = [
 
 import Branding from "@components/Branding.astro";
 import Column from "@components/Column.astro";
+import ExternalLink from "@components/ExternalLink.astro";
 import GoogleForm from "@components/forms/GoogleForm.astro";
 import ImageHeading from "@components/ImageHeading.astro";
 import Layout from "src/layouts/Layout.astro";
@@ -168,9 +169,9 @@ import ThemedSection from "@components/ThemedSection.astro";
             </select>
             <div id="timezoneHelpLink" class="form-text small">
               Not sure what your time zone is?
-              <a href="https://time.is/" target="_blank" rel="noopener noreferrer">
-                Find your current time zone and UTC offset.
-              </a>
+              <ExternalLink href="https://time.is/">
+                Find your current time zone and UTC offset
+              </ExternalLink>.
             </div>
           </fieldset>
         </Column>

--- a/astro/src/pages/mutua11y/protege-registration.astro
+++ b/astro/src/pages/mutua11y/protege-registration.astro
@@ -133,7 +133,7 @@ import ThemedSection from "@components/ThemedSection.astro";
             We will use this information to try and best match your geographic region, timezone and spoken languages whenever possible.
           </p>
         </Column>
-        <Column noDefault md="6" class="mb-3">
+        <Column noDefault lg="6" class="mb-3">
           <fieldset>
             <legend class="mb-1 fs-6 required-field">
               What region do you primarily live and work in? <span class="asterisk" aria-hidden="true"></span>
@@ -151,7 +151,7 @@ import ThemedSection from "@components/ThemedSection.astro";
             </select>
           </fieldset>
         </Column>
-        <Column noDefault md="6" class="mb-3">
+        <Column noDefault lg="6" class="mb-3">
           <fieldset>
             <legend class="mb-1 fs-6 required-field">
               What timezone do you live in? <span class="asterisk" aria-hidden="true"></span>

--- a/astro/src/pages/mutua11y/protege-registration.astro
+++ b/astro/src/pages/mutua11y/protege-registration.astro
@@ -160,11 +160,18 @@ import ThemedSection from "@components/ThemedSection.astro";
               class="form-select mb-2"
               name="Timezone"
               aria-label="Timezone selection"
+              aria-describedby="regionHelpLink"
               required
             >
               <option value="" selected disabled aria-disabled="false">Select the timezone you live in...</option>
               { timeZones.map((tz) => <option value={tz} set:text={tz} />) }
             </select>
+            <div id="regionHelpLink" class="form-text small">
+              Not sure what your time zone is?
+              <a href="https://time.is/" target="_blank" rel="noopener noreferrer">
+                Find your current time zone and UTC offset.
+              </a>
+            </div>
           </fieldset>
         </Column>
         <div class="col-12 mb-3">

--- a/astro/src/pages/mutua11y/protege-registration.astro
+++ b/astro/src/pages/mutua11y/protege-registration.astro
@@ -160,13 +160,13 @@ import ThemedSection from "@components/ThemedSection.astro";
               class="form-select mb-2"
               name="Timezone"
               aria-label="Timezone selection"
-              aria-describedby="regionHelpLink"
+              aria-describedby="timezoneHelpLink"
               required
             >
               <option value="" selected disabled aria-disabled="false">Select the timezone you live in...</option>
               { timeZones.map((tz) => <option value={tz} set:text={tz} />) }
             </select>
-            <div id="regionHelpLink" class="form-text small">
+            <div id="timezoneHelpLink" class="form-text small">
               Not sure what your time zone is?
               <a href="https://time.is/" target="_blank" rel="noopener noreferrer">
                 Find your current time zone and UTC offset.

--- a/astro/src/pages/mutua11y/protege-registration.astro
+++ b/astro/src/pages/mutua11y/protege-registration.astro
@@ -156,21 +156,21 @@ import ThemedSection from "@components/ThemedSection.astro";
         <Column noDefault lg="6" class="mb-3">
           <fieldset>
             <legend class="mb-1 fs-6 required-field">
-              What timezone do you live in? <span class="asterisk" aria-hidden="true"></span>
+              What time zone do you live in? <span class="asterisk" aria-hidden="true"></span>
             </legend>
             <select
               class="form-select mb-2"
-              name="Timezone"
-              aria-label="Timezone selection"
-              aria-describedby="timezoneHelpLink"
+              name="TimeZone"
+              aria-label="Time zone selection"
+              aria-describedby="timeZoneHelpLink"
               required
             >
-              <option value="" selected disabled aria-disabled="false">Select the timezone you live in...</option>
+              <option value="" selected disabled aria-disabled="false">Select the time zone you live in...</option>
               { timeZones.map((tz) => <option value={tz} set:text={tz} />) }
             </select>
-            <div id="timezoneHelpLink" class="form-text small">
+            <div id="timeZoneHelpLink" class="form-text small">
               Not sure what your time zone is?
-              <ExternalLink href="https://time.is/">
+              <ExternalLink href="https://time.is/your_time_zone">
                 Find your current time zone and UTC offset
               </ExternalLink>.
             </div>

--- a/astro/src/pages/mutua11y/protege-registration.astro
+++ b/astro/src/pages/mutua11y/protege-registration.astro
@@ -132,7 +132,7 @@ import ThemedSection from "@components/ThemedSection.astro";
         <Column noDefault md="12" class="mb-3">
           <h3 class="display-5">Your location and language information</h3>
           <p class="form-text">
-            We will use this information to try and best match your geographic region, timezone and spoken languages whenever possible.
+            We will use this information to try and best match your geographic region, time zone and spoken languages whenever possible.
           </p>
         </Column>
         <Column noDefault lg="6" class="mb-3">

--- a/astro/src/pages/mutua11y/protege-registration.astro
+++ b/astro/src/pages/mutua11y/protege-registration.astro
@@ -138,7 +138,8 @@ import ThemedSection from "@components/ThemedSection.astro";
         <Column noDefault lg="6" class="mb-3">
           <fieldset>
             <legend class="mb-1 fs-6 required-field">
-              What region do you primarily live and work in? <span class="asterisk" aria-hidden="true"></span>
+              What region do you primarily live and work in?
+              <span class="asterisk" aria-hidden="true"></span>
             </legend>
             <select
               class="form-select mb-2"
@@ -156,7 +157,9 @@ import ThemedSection from "@components/ThemedSection.astro";
         <Column noDefault lg="6" class="mb-3">
           <fieldset>
             <legend class="mb-1 fs-6 required-field">
-              What time zone do you live in? <span class="asterisk" aria-hidden="true"></span>
+              What time zone do you live in?
+              <span class="asterisk" aria-hidden="true"></span>
+              <span class="form-text">(UTC stands for Universal Coordinated Time)</span>
             </legend>
             <select
               class="form-select mb-2"
@@ -171,7 +174,7 @@ import ThemedSection from "@components/ThemedSection.astro";
             <div id="timeZoneHelpLink" class="form-text small">
               Not sure what your time zone is?
               <ExternalLink href="https://time.is/your_time_zone">
-                Find your current time zone and UTC offset
+                Find your time zone and UTC offset
               </ExternalLink>.
             </div>
           </fieldset>


### PR DESCRIPTION
Add instructions to both mutua11y forms for how the user can find their time zone (for the time zone dropdown selection). These instructions were taken from those used for the loca11y interview form, so they are being added to improve user experience. Additional information of what UTC stands for is added as well. "Timezone" has also been changed to "time zone" for consistency.

Fixes #541 