### PR TITLE
Issue #580: Remove deprecated frameborder from volunteer iframe

### DIFF
--- a/astro/src/pages/volunteer.astro
+++ b/astro/src/pages/volunteer.astro
@@ -133,7 +133,6 @@ const orderedTeams = sortBy(teams, ["data.name"]);
         height="315"
         src="https://www.youtube-nocookie.com/embed/ytD-B97X0NQ?si=iObRC-aeuvZvCuv8"
         title="YouTube video player"
-        frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         referrerpolicy="strict-origin-when-cross-origin"
         allowfullscreen></iframe>


### PR DESCRIPTION
## Summary
- Remove the deprecated `frameborder=0` attribute from the Volunteer page iframe

## Verification
- Confirmed the PR diff only changes `astro/src/pages/volunteer.astro`
- Not run locally: repository clone timed out in this environment, so this was committed through the GitHub API

Closes #580