### PR TITLE
Remove unused imports from page group

### DIFF
--- a/astro/src/pages/about/mission.astro
+++ b/astro/src/pages/about/mission.astro
@@ -7,7 +7,6 @@ import Layout from "../../layouts/Layout.astro";
 import Quote from "../../components/Quote.astro";
 import Row from "../../components/Row.astro";
 import ShadowBoxSection from "../../components/ShadowBoxSection.astro";
-import ThemedBox from "../../components/ThemedBox.astro";
 import ThemedColumn from "../../components/ThemedColumn.astro";
 import ThemedSection from "../../components/ThemedSection.astro";
 import { Image } from "astro:assets";

--- a/astro/src/pages/about/story.astro
+++ b/astro/src/pages/about/story.astro
@@ -3,7 +3,6 @@ import ExternalLink from "../../components/ExternalLink.astro";
 import ImageHeading from "../../components/ImageHeading.astro";
 import Layout from "../../layouts/Layout.astro";
 import TeamVignette from "../../components/TeamVignette.astro";
-import ThemedBox from "../../components/ThemedBox.astro";
 import ThemedColumn from "../../components/ThemedColumn.astro";
 import ThemedSection from "../../components/ThemedSection.astro";
 import { Icon } from "astro-icon/components";

--- a/astro/src/pages/blog/rss.xml.ts
+++ b/astro/src/pages/blog/rss.xml.ts
@@ -8,7 +8,7 @@ import { getContainerRenderer as mdxRenderer } from "@astrojs/mdx";
 
 import { render, type CollectionEntry } from "astro:content";
 import { orderByRecent } from "../../lib/blog";
-import { components, sanitizeOptions } from "../../lib/mdx";
+import { sanitizeOptions } from "../../lib/mdx";
 
 const renderers = await loadRenderers([mdxRenderer()]);
 const container = await AstroContainer.create({ renderers });

--- a/astro/src/pages/donate.astro
+++ b/astro/src/pages/donate.astro
@@ -2,9 +2,8 @@
 import type { PageMetadata } from "@lib/types";
 import { getOpenGraphImageData } from "@lib/og-image";
 import components from "@lib/mdx";
-import { getEntry, render, type CollectionEntry } from "astro:content";
+import { getEntry, render } from "astro:content";
 
-import Branding from "../components/Branding.astro";
 import Column from "../components/Column.astro";
 import Hero from "../components/Hero.astro";
 import { Icon } from "astro-icon/components";
@@ -16,10 +15,8 @@ import TeamVignette from "@components/TeamVignette.astro";
 import ThemedSection from "../components/ThemedSection.astro";
 
 import heroBg from "../images/colored-hero/donate.png";
-import rachael from "../images/rachael-at-booth.jpg";
 
 import ThemedBox from "@components/ThemedBox.astro";
-import { Image } from "astro:assets";
 const directorEmail = "mailto:director@accessiblecommunity.org";
 const paypalUrl = "https://paypal.me/AccessibleCommunity";
 const stripeUrl = "https://donate.stripe.com/eVadR0agM8ec1TW5kk";
@@ -44,19 +41,16 @@ const donationLinks = [
     icon: "cib:cc-paypal",
     href: paypalUrl,
     title: "Donate via Paypal",
-    theme: "paypal",
   },
   {
     icon: "cib:cc-stripe",
     href: stripeUrl,
     title: "Donate via Stripe",
-    theme: "stripe",
   },
   {
     icon: "envelope-at",
     href: directorEmail,
     title: "Email the Director",
-    theme: "primary",
   },
 ];
 
@@ -70,19 +64,6 @@ const metadata: PageMetadata = {
 const letter = await getEntry("markdown", "donor-letter");
 if (!letter) throw new Error("Could not find content `markdown/donor-letter`");
  const { Content } = await render(letter);
-
-const statesRegistered = ["Maryland", "Virginia"];
-const statesAccepting = [
-  "Delaware",
-  "Idaho",
-  "Indiana",
-  "Iowa",
-  "Montana",
-  "Nebraska",
-  "South Dakota",
-  "Vermont",
-  "Wyoming",
-];
 ---
 
 <Layout {title} {metadata}>
@@ -173,7 +154,7 @@ const statesAccepting = [
           class="d-grid d-sm-flex flex-lg-column justify-content-sm-center gap-3 pb-3"
         >
           {
-            donationLinks.map(({ icon, href, title, theme }) => (
+            donationLinks.map(({ icon, href, title }) => (
               <a
                 class:list={[`btn btn-sm btn-primary rounded-2 shadow-sm`]}
                 href={href}

--- a/astro/src/pages/podcasts/index.astro
+++ b/astro/src/pages/podcasts/index.astro
@@ -11,13 +11,6 @@ const shows: CollectionEntry<"podcastShows">[] = sortBy(
   await getCollection("podcastShows"),
   [(show) => show.data.title],
 );
-const staff: CollectionEntry<"staff">[] = sortBy(
-  await getCollection(
-    "staff", ({data}) => data.current && Object.keys(data.roles ?? {}).includes("podcasts")
-  ),
-  // Alphabetize by first name
-  ({data}) => data.cited?.first ?? data.name.first,
-);
 
 function toUrlMap(links: PodcastLinks): SocialLinkDictionary {
   const urlMap: SocialLinkDictionary = {};

--- a/astro/src/pages/tips/rss.xml.ts
+++ b/astro/src/pages/tips/rss.xml.ts
@@ -9,7 +9,7 @@ import { getContainerRenderer as mdxRenderer } from "@astrojs/mdx";
 import type { CollectionEntry } from "astro:content";
 import { render } from "astro:content";
 import { orderByRecent } from "src/lib/tips";
-import { components, sanitizeOptions } from "src/lib/mdx";
+import { sanitizeOptions } from "src/lib/mdx";
 
 const renderers = await loadRenderers([mdxRenderer()]);
 const container = await AstroContainer.create({ renderers });


### PR DESCRIPTION
Addresses part of #581.

This removes unused imports and unused declarations from the first suggested page group:

- `src/pages/donate.astro`
- `src/pages/about/mission.astro`
- `src/pages/about/story.astro`
- `src/pages/blog/rss.xml.ts`
- `src/pages/tips/rss.xml.ts`
- `src/pages/podcasts/index.astro`

Validation:

- `npm run build`
- `npx astro check` was also run with temporary local check dependencies; it still reports pre-existing diagnostics outside this change, but the cleaned unused-import warnings from this subset no longer appear.