### PR TITLE
Remove extra h1 from "Podcast" landing page

### DIFF
--- a/astro/src/pages/podcasts/index.astro
+++ b/astro/src/pages/podcasts/index.astro
@@ -63,7 +63,7 @@ import ThemedSection from "@components/ThemedSection.astro";
 
 <Layout title="Our Podcast" {metadata}>
   <ImageHeading image="podcast" slot="header">
-    <h1 class="display-3">Podcast Series</h1>
+    Podcast Series
   </ImageHeading>
   <ThemedSection yPaddings={['3']}>
     <ThemedBox theme="primary" style="subtle" border={1} padding={3} class="rounded mb-4">


### PR DESCRIPTION
Fixes #612 